### PR TITLE
Use simple date strings for datetime searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- #33: Simple date string search for items
+
 ### Fixed
 
 ### Changed

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,6 @@
 
 import re
 import sys
-import toml
 from pathlib import Path
 
 # -- Path setup --------------------------------------------------------------
@@ -25,16 +24,7 @@ copyright = '2021, Jon Duckworth'
 author = 'Jon Duckworth'
 github_user = 'duckontheweb'
 github_repo = 'pystac-api-client'
-
-# Get the package description
-try:
-    pyproject_file = Path(__file__).parent.parent.parent / 'pyproject.toml'
-    with pyproject_file.open('r') as src:
-        pyproject = toml.load(src)
-
-    package_description = pyproject.get('tool', {}).get('poetry', {}).get('description', '')
-except Exception:
-    package_description = ''
+package_description = 'A Python client for the STAC API spec.'
 
 # The full version, including alpha/beta/rc tags
 version = re.fullmatch(r'^(\d+\.\d+\.\d).*$', __version__).group(1)

--- a/pystac_client/api.py
+++ b/pystac_client/api.py
@@ -181,15 +181,28 @@ class API(pystac.Catalog, STACAPIObjectMixin):
             May be a list, tuple, or iterator representing a bounding box of 2D or 3D coordinates. Results will be
             filtered to only those intersecting the bounding box.
         datetime: str or datetime.datetime or list or tuple or Iterator, optional
-            Either a single datetime or datetime range used to filter results. You may express a single datetime using
-            a :class:`datetime.datetime` instance or a `RFC 3339-compliant <https://tools.ietf.org/html/rfc3339>`__
-            timestamp. Instances of :class:`datetime.datetime` may be either timezone aware or unaware. Timezone aware
-            instances will be converted to a UTC timestamp before being passed to the endpoint. Timezone unaware
-            instances are assumed to represent UTC timestamps.
-            You may represent a datetime range using a ``"/"`` separated string as described in the spec, or a list,
-            tuple, or iterator of 2 timestamps or datetime instances. For open-ended ranges, use either ``".."``
-            (``'2020-01-01:00:00:00Z/..'``, ``['2020-01-01:00:00:00Z', '..']``) or a value of ``None``
-            (``['2020-01-01:00:00:00Z', None]``).
+            Either a single datetime or datetime range used to filter results. You may express a single datetime using a
+            :class:`datetime.datetime` instance, a `RFC 3339-compliant <https://tools.ietf.org/html/rfc3339>`__ timestamp,
+            or a simple date string (see below). Instances of :class:`datetime.datetime` may be either timezone aware or
+            unaware. Timezone aware instances will be converted to a UTC timestamp before being passed to the endpoint.
+            Timezone unaware instances are assumed to represent UTC timestamps. You may represent a datetime range using a
+            ``"/"`` separated string as described in the spec, or a list, tuple, or iterator of 2 timestamps or datetime
+            instances. For open-ended ranges, use either ``".."`` (``'2020-01-01:00:00:00Z/..'``,
+            ``['2020-01-01:00:00:00Z', '..']``) or a value of ``None`` (``['2020-01-01:00:00:00Z', None]``).
+
+            If using a simple date string, the datetime can be specified in ``YYYY-mm-dd`` format, optionally truncating
+            to ``YYYY-mm`` or just ``YYYY``. Simple date strings will be expanded to include the entire time period, for
+            example:
+
+            - ``2017`` expands to ``2017-01-01T00:00:00Z/2017-12-31T23:59:59Z``
+            - ``2017-06`` expands to ``2017-06-01T00:00:00Z/2017-06-30T23:59:59Z``
+            - ``2017-06-10`` expands to ``2017-06-10T00:00:00Z/2017-06-10T23:59:59Z``
+
+            If used in a range, the end of the range expands to the end of that day/month/year, for example:
+
+            - ``2017/2018`` expands to ``2017-01-01T00:00:00Z/2018-12-31T23:59:59Z``
+            - ``2017-06/2017-07`` expands to ``2017-06-01T00:00:00Z/2017-07-31T23:59:59Z``
+            - ``2017-06-10/2017-06-11`` expands to ``2017-06-10T00:00:00Z/2017-06-11T23:59:59Z``
         intersects: str or dict, optional
             A GeoJSON-like dictionary or JSON string. Results will be filtered to only those intersecting the geometry
         ids: list, optional

--- a/pystac_client/stac_io.py
+++ b/pystac_client/stac_io.py
@@ -19,7 +19,7 @@ def read_text_method(uri):
     if bool(urlparse(uri).scheme):
         logger.debug(f"Requesting {uri}")
         resp = requests.get(uri)
-        return requests.get(uri).content
+        return resp.content
     else:
         return STAC_IO.default_read_text_method(uri)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers = 
+    vcr: records network activity

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -97,6 +97,42 @@ class TestItemSearchParams:
         search = ItemSearch(url=ASTRAEA_URL, datetime=start_localized)
         assert search.request.json['datetime'] == '2020-02-01T05:00:00Z'
 
+    def test_single_year(self):
+        search = ItemSearch(url=ASTRAEA_URL, datetime='2020')
+        assert search.request.json['datetime'] == "2020-01-01T00:00:00Z/2020-12-31T23:59:59Z"
+
+    def test_range_of_years(self):
+        search = ItemSearch(url=ASTRAEA_URL, datetime='2019/2020')
+        assert search.request.json['datetime'] == "2019-01-01T00:00:00Z/2020-12-31T23:59:59Z"
+
+    def test_single_month(self):
+        search = ItemSearch(url=ASTRAEA_URL, datetime='2020-06')
+        assert search.request.json['datetime'] == "2020-06-01T00:00:00Z/2020-06-30T23:59:59Z"
+
+    def test_range_of_months(self):
+        search = ItemSearch(url=ASTRAEA_URL, datetime='2020-04/2020-06')
+        assert search.request.json['datetime'] == "2020-04-01T00:00:00Z/2020-06-30T23:59:59Z"
+
+    def test_single_date(self):
+        search = ItemSearch(url=ASTRAEA_URL, datetime='2020-06-10')
+        assert search.request.json['datetime'] == "2020-06-10T00:00:00Z/2020-06-10T23:59:59Z"
+
+    def test_range_of_dates(self):
+        search = ItemSearch(url=ASTRAEA_URL, datetime='2020-06-10/2020-06-20')
+        assert search.request.json['datetime'] == "2020-06-10T00:00:00Z/2020-06-20T23:59:59Z"
+
+    def test_mixed_simple_date_strings(self):
+        search = ItemSearch(url=ASTRAEA_URL, datetime="2019/2020-06-10")
+        assert search.request.json['datetime'] == "2019-01-01T00:00:00Z/2020-06-10T23:59:59Z"
+
+    def test_three_datetimes(self):
+        start = datetime(2020, 2, 1, 0, 0, 0, tzinfo=tzutc())
+        middle = datetime(2020, 2, 2, 0, 0, 0, tzinfo=tzutc())
+        end = datetime(2020, 2, 3, 0, 0, 0, tzinfo=tzutc())
+
+        with pytest.raises(Exception):
+            ItemSearch(url=ASTRAEA_URL, datetime=[start, middle, end])
+
     def test_single_collection_string(self):
         # Single ID string
         search = ItemSearch(url=ASTRAEA_URL, collections='naip')


### PR DESCRIPTION
**Related Issue(s):** #29 


**Description:**
Enables use of simple date strings, e.g. `2017` or `2017-06-10/2017-06-20`, when searching for items.

Sidecar:
- Removes an unused variable
- Re-adds pytest marker registration for `vcr` to get the tests to quiet down
- Fixes the project description string in the Sphinx docs

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass (sorta, my new tests pass but the suite is still broken)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)

Closes #29.