### PR TITLE
Fix get_collections_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Running `stac-client` with no arguments no longer raises a confusing exception [#52](https://github.com/stac-utils/pystac-client/pull/52)
+- `Client.get_collections_list` [#44](https://github.com/stac-utils/pystac-client/issues/44)
 
 ## [v0.1.1] - 2021-04-16
 

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -162,7 +162,6 @@ class Client(pystac.Catalog, STACAPIObjectMixin):
 
         return catalog
 
-    @classmethod
     def get_collections_list(self):
         """Gets list of available collections from this Catalog. Alias for get_child_links since children
             of an API are always and only ever collections

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,6 +28,9 @@ class TestAPI:
         collection_links = api.get_links('child')
         assert len(collection_links) > 0
 
+        collection_links_alt = api.get_collections_list()
+        assert len(collection_links) == len(collection_links_alt)
+
         first_collection = api.get_single_link('child').resolve_stac_object(root=api).target
         assert isinstance(first_collection, pystac.Collection)
 


### PR DESCRIPTION
**Related Issue(s):** #44


**Description:** It was labelled as a classmethod but it's not. Includes regression test.


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)