### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,4 +21,4 @@ python:
   install:
     - method: pip
       path: .
-    - requirements: requirements_docs.txt
+    - requirements: requirements-docs.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `ItemSearch.items_as_collection` [#37](https://github.com/stac-utils/pystac-client/pull/37)
+- Documentation [published on ReadTheDocs](https://pystac-client.readthedocs.io/en/latest/) [#46](https://github.com/stac-utils/pystac-client/pull/46)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ STAC API Client
 [![CI](https://github.com/stac-utils/pystac-client/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/stac-utils/pystac-client/actions/workflows/continuous-integration.yml)
 [![Release](https://github.com/stac-utils/pystac-client/actions/workflows/release.yml/badge.svg)](https://github.com/stac-utils/pystac-client/actions/workflows/release.yml)
 [![PyPI version](https://badge.fury.io/py/pystac-client.svg)](https://badge.fury.io/py/pystac-client)
-[![Documentation](https://readthedocs.org/projects/pystac_client/badge/?version=latest)](https://pystac_client.readthedocs.io/en/latest/)
+[![Documentation](https://readthedocs.org/projects/pystac-client/badge/?version=latest)](https://pystac-client.readthedocs.io/en/latest/)
 [![codecov](https://codecov.io/gh/stac-utils/pystac-client/branch/main/graph/badge.svg)](https://codecov.io/gh/stac-utils/pystac-client)
+
 
 A Python client for working with [STAC](https://stacspec.org/) Catalogs and APIs.
 
@@ -16,6 +17,10 @@ Install from PyPi. Other than PySTAC itself, the only dependency for pystac-clie
 ```shell
 pip install pystac-client
 ```
+
+## Documentation
+
+See the [documentation page](https://pystac-client.readthedocs.io/en/latest/) for the latest docs.
 
 ## Usage
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,1 @@
+recommonmark~=0.7.1


### PR DESCRIPTION
**Related Issue(s):** #

* #16 

**Description:**

Adds `requirements-docs.txt` with dependencies for building docs in ReadTheDocs (currently just `recommonmark`)

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)