### PR TITLE
Print usage when running cli without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `Client.open` falls back to the `STAC_URL` environment variable if no url is provided as an argument [#48](https://github.com/stac-utils/pystac-client/pull/48)
 
+### Fixed
+
+- Running `stac-client` with no arguments no longer raises a confusing exception [#52](https://github.com/stac-utils/pystac-client/pull/52)
+
 ## [v0.1.1] - 2021-04-16
 
 ### Added

--- a/pystac_client/cli.py
+++ b/pystac_client/cli.py
@@ -94,6 +94,9 @@ def parse_args(args):
     output_group.add_argument('--save', help='Filename to save Item collection to', default=None)
 
     parsed_args = {k: v for k, v in vars(parser0.parse_args(args)).items() if v is not None}
+    if "command" not in parsed_args:
+        parser0.print_usage()
+        return []
 
     # if intersects is JSON file, read it in
     if 'intersects' in parsed_args:
@@ -123,6 +126,8 @@ def parse_args(args):
 
 def cli():
     args = parse_args(sys.argv[1:])
+    if not args:
+        return None
 
     loglevel = args.pop('logging')
     # don't enable logging if print to stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,3 +10,8 @@ class TestCLI:
         args = ["stac-client", "search", "--url", ASTRAEA_URL, "-c", "naip", "--max-items", "20"]
         result = script_runner.run(*args, print_result=False)
         assert result.success
+
+    def test_no_arguments(self, script_runner: ScriptRunner):
+        args = ["stac-client"]
+        result = script_runner.run(*args, print_result=False)
+        assert result.success


### PR DESCRIPTION
**Related Issue(s):** #51 


**Description:** Checks to see if there's no command and, if so, prints usage. I don't error (contra the original issue) because I don't feel like a naked invocation is an error, but if others feel differently I'm happy to change.


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)