### PR TITLE
Set client Catalog as Item root in ItemSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ items.save('items.json')
 
 ## Development
 
+### Install
+
+```shell
+$ pip install -e .
+$ pip install -r requirements-dev.txt
+```
+
 ### Build Docs
 
 ```shell

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -190,4 +190,5 @@ class Client(pystac.Catalog, ConformanceMixin):
         return ItemSearch(search_link.target,
                           conformance=self.conformance,
                           stac_io=self._stac_io,
+                          client=self,
                           **kwargs)

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -5,7 +5,7 @@ import re
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from datetime import timezone, datetime as datetime_
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Dict, Iterator, List, Optional, TYPE_CHECKING, Tuple, Union
 import warnings
 
 from pystac import Collection, Item, ItemCollection, Link
@@ -13,6 +13,9 @@ from pystac.stac_io import StacIO
 
 from pystac_client.stac_io import StacApiIO
 from pystac_client.conformance import ConformanceClasses, ConformanceMixin
+
+if TYPE_CHECKING:
+    from pystac_client.client import Client
 
 DATETIME_REGEX = re.compile(
     r"(?P<year>\d{4})(\-(?P<month>\d{2})(\-(?P<day>\d{2})"
@@ -162,10 +165,12 @@ class ItemSearch(ConformanceMixin):
                  fields: Optional[FieldsLike] = None,
                  max_items: Optional[int] = None,
                  method: Optional[str] = 'POST',
-                 stac_io: Optional[StacIO] = None):
+                 stac_io: Optional[StacIO] = None,
+                 client: Optional["Client"] = None):
         self.url = url
         self.conformance = conformance
         self.conforms_to(ConformanceClasses.ITEM_SEARCH)
+        self.client = client
 
         if stac_io:
             self._stac_io = stac_io

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -418,7 +418,7 @@ class ItemSearch(ConformanceMixin):
         item_collection : pystac_client.ItemCollection
         """
         for page in self.get_pages():
-            yield ItemCollection.from_dict(page)
+            yield ItemCollection.from_dict(page, root=self.client)
 
     def item_collections(self) -> Iterator[ItemCollection]:
         warnings.warn("Search.item_collections is deprecated, please use get_item_collections")


### PR DESCRIPTION
**Related Issue(s):** # https://github.com/stac-utils/pystac/issues/546

**Description:**
This PR passes in the client Catalog as the root of Items in an ItemCollection for ItemSearchs produced by that client Catalog.

This allows PySTAC logic that depends on reading the root of an object to perform significantly faster.

This makes the assumption that the root of the Items produced by a STAC API search should always be pointed back to the STAC API, which I think is a fair assumption.

This PR relies on changes in PySTAC contained in https://github.com/stac-utils/pystac/pull/549. Making this PR as a draft until upstream changes are available.

**PR Checklist:**

- [ ] Code is formatted
- [ ] Tests pass
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)