### PR TITLE
Add a performance test and benchmarks for getting items

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ codespell==1.17.1
 coverage==5.2.*
 flake8==3.8.*
 pytest~=6.2.3
+pytest-benchmark~=3.4.1
 pytest-cov~=2.11.1
 pytest-recording~=0.11.0
 pytest-console-scripts~=1.1.0


### PR DESCRIPTION
**Related Issue(s):** none

**Description:**

I'm trying to optimise performance in a tool that uses the client and wanted to benchmark the item retrieval.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)