### PR TITLE
Allow logging even when printing to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Logging is now enabled in the CLI in all cases.
+  If data are being printed to stdout, logging goes to stderr.
+  [#79](https://github.com/stac-utils/pystac-client/pull/79)
+
 ## [v0.2.0-rc.1] - 2021-07-30
 
 ### Added

--- a/pystac_client/cli.py
+++ b/pystac_client/cli.py
@@ -155,11 +155,14 @@ def cli():
         return None
 
     loglevel = args.pop('logging')
-    # don't enable logging if print to stdout
     if args.get('save', False) or args.get('matched', False):
-        logging.basicConfig(stream=sys.stdout, level=loglevel)
-        # quiet loggers
-        logging.getLogger("urllib3").propagate = False
+        # If we are not printing data to stdout, print the logs there instead.
+        stream = sys.stdout
+    else:
+        stream = sys.stderr
+    logging.basicConfig(stream=stream, level=loglevel)
+    # quiet loggers
+    logging.getLogger("urllib3").propagate = False
 
     if args.get('url', None) is None:
         raise RuntimeError('No STAC URL provided')


### PR DESCRIPTION
**Related Issue(s):** n/a


**Description:** I found it surprising when `--logging DEBUG` didn't change anything, but then discovered that logging is silently disabled if the cli is printing to stdout. This PR enables logging in all cases, printing to stderr if data are being printed to stdout. This enables logging+piping, e.g.

> stac-client search .. --logging DEBUG > out.json

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)