### PR TITLE
Relax requests dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Relax `requests` dependency [#87](https://github.com/stac-utils/pystac-client/pull/87)
+
 ## [v0.2.0] - 2021-08-04
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     include_package_data=False,
     install_requires=[
         "python-dateutil>=2.7.0",
-        "requests~=2.25.1",
+        "requests~=2.25",
         "pystac~=1.1.0"
     ],
     extras_require={


### PR DESCRIPTION
**Related Issue(s):** #86


**Description:** Relaxes requests dependency. `requests~=2.25` is the same as the `requests>=2.25, <3` mentioned in the motivating issue.


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)