### PR TITLE
Fixed collections conformance URL

### DIFF
--- a/pystac_client/conformance.py
+++ b/pystac_client/conformance.py
@@ -40,7 +40,7 @@ class ConformanceClasses(Enum):
     SORT = [f"{p}/item-search#sort" for p in STAC_PREFIXES]
     QUERY = [f"{p}/item-search#query" for p in STAC_PREFIXES]
     FILTER = [f"{p}/item-search#filter" for p in STAC_PREFIXES]
-    COLLECTIONS = ['http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30']
+    COLLECTIONS = ['http://www.opengis.net/spec/ogcapi-features-1/1.0/req/oas30']
 
 
 CONFORMANCE_URIS = {c.name: c.value for c in ConformanceClasses}


### PR DESCRIPTION
With the caveat that I don't really know what a conformance class is, I think the COLLECTIONS URL is incorrect. http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30 gives a 404, while http://www.opengis.net/spec/ogcapi-features-1/1.0/req/oas30 is valid and is what's published by stac-fastapi.

However, see https://github.com/stac-utils/stac-fastapi/issues/255, which might be changing this. Let's hold on this PR till that's sorted out.