### PR TITLE
when using shortcut query syntax, cast gsd to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `ItemSearch` now correctly handles times without a timezone specifier [#92](https://github.com/stac-utils/pystac-client/issues/92)
+- queries including `gsd` cast to string to float when using shortcut query syntax (i.e., "key=val" strings). [#98](https://github.com/stac-utils/pystac-client/pull/97)
 
 ## [v0.2.0] - 2021-08-04
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,14 @@ the specified file.
 $ stac-client search ${STAC_API_URL} -c sentinel-s2-l2a-cogs --bbox -72.5 40.5 -72 41 --datetime 2020-01-01/2020-01-31 --save items.json
 ```
 
-If the Catalog supports the [Query extension](https://github.com/radiantearth/stac-api-spec/tree/master/fragments/query),
-any Item property can also be included in the search. Rather than requiring the JSON syntax the Query extension uses,
-pystac-client uses a simpler syntax that it will translate to the JSON equivalent. 
+If the Catalog supports the
+[Query extension](https://github.com/radiantearth/stac-api-spec/tree/master/fragments/query), 
+any Item property can also be included in the search. Rather than requiring the JSON syntax 
+the Query extension uses, pystac-client uses a simpler syntax that it will translate to the 
+JSON equivalent. Note however that when the simple syntax is used it sends all property values
+to the server as strings, except for `gsd` which it casts to `float`. This means that if there
+are extensions in use with numeric properties these will be sent as strings. Some servers
+may automatically cast this to the appropriate data type, others may not.
 
 ```
 <property><operator><value>

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -225,7 +225,11 @@ class ItemSearch:
                 for op in ['>=', '<=', '=', '>', '<']:
                     parts = q.split(op)
                     if len(parts) == 2:
-                        query = dict_merge(query, {parts[0]: {OP_MAP[op]: parts[1]}})
+                        param = parts[0]
+                        val = parts[1]
+                        if param == "gsd":
+                            val = float(val)
+                        query = dict_merge(query, {parts[0]: {OP_MAP[op]: val}})
                         break
         else:
             query = value

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -370,26 +370,21 @@ class TestItemSearch:
 
 
 class TestItemSearchQuery:
-
     def test_query_shortcut_syntax(self):
-        search = ItemSearch(
-            url=SEARCH_URL,
-            bbox=(-73.21, 43.99, -73.12, 44.05),
-            query=["gsd=10"],
-            max_items=1
-        )
+        search = ItemSearch(url=SEARCH_URL,
+                            bbox=(-73.21, 43.99, -73.12, 44.05),
+                            query=["gsd=10"],
+                            max_items=1)
         items1 = list(search.get_items())
 
-        search = ItemSearch(
-            url=SEARCH_URL,
-            bbox=(-73.21, 43.99, -73.12, 44.05),
-            query={
-                "gsd": {"eq": 10}
-            },
-            max_items=1
-        )
+        search = ItemSearch(url=SEARCH_URL,
+                            bbox=(-73.21, 43.99, -73.12, 44.05),
+                            query={"gsd": {
+                                "eq": 10
+                            }},
+                            max_items=1)
         items2 = list(search.get_items())
 
-        assert(len(items1) == 1)
-        assert(len(items2) == 1)
-        assert(items1[0].id == items2[0].id)
+        assert (len(items1) == 1)
+        assert (len(items2) == 1)
+        assert (items1[0].id == items2[0].id)

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -367,3 +367,29 @@ class TestItemSearch:
         )
         item_collection = search.get_all_items()
         assert len(item_collection.items) == 20
+
+
+class TestItemSearchQuery:
+
+    def test_query_shortcut_syntax(self):
+        search = ItemSearch(
+            url=SEARCH_URL,
+            bbox=(-73.21, 43.99, -73.12, 44.05),
+            query=["gsd=10"],
+            max_items=1
+        )
+        items1 = list(search.get_items())
+
+        search = ItemSearch(
+            url=SEARCH_URL,
+            bbox=(-73.21, 43.99, -73.12, 44.05),
+            query={
+                "gsd": {"eq": 10}
+            },
+            max_items=1
+        )
+        items2 = list(search.get_items())
+
+        assert(len(items1) == 1)
+        assert(len(items2) == 1)
+        assert(items1[0].id == items2[0].id)


### PR DESCRIPTION
**Related Issue(s):** #
#80 

**Description:**
This fixes the issue raised in #80 which is that, when using the pystac-client shortcut syntax for query (provided as string "KEY=VAL" pairs) then all parameters are sent to the server as string.  With Earth-search (backed by Elasticsearch) this still works as intended, but in stac-fastapi is respects the type sent in the query so finds no results.

The obvious workaround here is to not use the pystac-client shortcut syntax and instead provide the full query JSON (which can also be provided, pystac-client search accepts either).

This PR does add a cast of `gsd` since it is the only core metadata field that isn't a string. AlthoughiIt's not a general fix for other parameters which may be numeric.

This PR also clarifies this side effect of the shortcut syntax.


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)