### PR TITLE
remove test as an installable package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- The tests folder is no longer installed as a package.
+
 ## [0.3.1] - 2021-11-17
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author="Jon Duckworth, Matthew Hanson",
     author_email='duckontheweb@gmail.com, matt.a.hanson@gmail.com',
     url='https://github.com/stac-utils/pystac-client.git',
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests",)),
     py_modules=[splitext(basename(path))[0] for path in glob('pystac_client/*.py')],
     include_package_data=False,
     python_requires=">=3.7",


### PR DESCRIPTION
**Related Issue(s):** #

`pystac-client` makes the same mistake as many other packages to ship the `tests` folder as a package, creating conflicts with other packages and using a namespace for something that is external to the main module. This causes pain when installing this package with others that make the same mistake and those verify the the contents the "`tests`" module b/c only the last one installed will win that space.


**Description:**

Removes the `tests` folder as a package.

**PR Checklist:**

- [X] Code is formatted
- [X] Tests pass
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)

Note that there are other ways to solve this:
- remove the `__init__.py` from the test folder to avoid making it discoverable by `find_packages()`
- remove it from the MANIFEST
- move the folder inside the main module and package it as a submodule

The first two are the same as this PR b/c it will just remove the tests from the tarball. That should be OK for a pure Python package but if shipping the tests is desirable then I can modify this PR to implement the last option above.