### PR TITLE
fix: fix bbox parameter formatting for GET search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Parameter formatting for GET searches in `ItemSearch.get_parameters` [#124](https://github.com/stac-utils/pystac-client/pull/124)
+
 ## [0.3.1] - 2021-11-17
 
 ### Changed

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -202,7 +202,7 @@ class ItemSearch:
         elif self.method == 'GET':
             params = deepcopy(self._parameters)
             if 'bbox' in params:
-                params['bbox'] = ','.join(params['bbox'])
+                params['bbox'] = ','.join(map(str, params['bbox']))
             if 'ids' in params:
                 params['ids'] = ','.join(params['ids'])
             if 'collections' in params:

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -279,8 +279,11 @@ class TestItemSearch:
     def test_method_params(self):
         params_in = {
             'bbox': (-72, 41, -71, 42),
-            'ids': ('idone', 'idtwo',),
-            'collections': ('collectionone',),
+            'ids': (
+                'idone',
+                'idtwo',
+            ),
+            'collections': ('collectionone', ),
             'intersects': INTERSECTS_EXAMPLE
         }
         # For POST this is pass through

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -276,6 +276,24 @@ class TestItemSearch:
         search = ItemSearch(url=SEARCH_URL, method='GET', intersects=INTERSECTS_EXAMPLE)
         assert search.method == 'GET'
 
+    def test_method_params(self):
+        params_in = {
+            'bbox': (-72, 41, -71, 42),
+            'ids': ('idone', 'idtwo',),
+            'collections': ('collectionone',),
+            'intersects': INTERSECTS_EXAMPLE
+        }
+        # For POST this is pass through
+        search = ItemSearch(url=SEARCH_URL, **params_in)
+        params = search.get_parameters()
+        assert params == search._parameters
+
+        # For GET requests, parameters are in query string and must be serialized
+        search = ItemSearch(url=SEARCH_URL, method='GET', **params_in)
+        params = search.get_parameters()
+        assert all(key in params for key in params_in)
+        assert all(isinstance(params[key], str) for key in params_in)
+
     @pytest.mark.vcr
     def test_results(self):
         search = ItemSearch(


### PR DESCRIPTION
**Related Issue(s):** #123

**Description:**

This PR fixes the conversion of the "bbox" search parameter for GET based searches where the information must be encoded as a comma separated string that goes into query string. The bbox is stored as part of `ItemSearch._parameters` as a `Tuple[float, float, float, float]` so each element must be converted to `str` before they can be used within `str.join`

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)