### PR TITLE
Propagate root StacAPIIO to ItemSearch in Client.get_items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Values from `parameters` and `headers` arguments to `Client.open` and `Client.from_file` are now also used in requests made from `CollectionClient` instances
+  fetched from the same API ([#126](https://github.com/stac-utils/pystac-client/pull/126))
+
 ## [0.3.1] - 2021-11-17
 
 ### Changed

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -89,7 +89,7 @@ class Client(pystac.Catalog):
         """
         if self._stac_io.conforms_to(ConformanceClasses.COLLECTIONS):
             url = f"{self.get_self_href()}/collections/{collection_id}"
-            collection = CollectionClient.from_dict(self._stac_io.read_json(url))
+            collection = CollectionClient.from_dict(self._stac_io.read_json(url), root=self)
             return collection
         else:
             for col in self.get_collections():

--- a/pystac_client/collection_client.py
+++ b/pystac_client/collection_client.py
@@ -23,7 +23,7 @@ class CollectionClient(pystac.Collection):
 
         link = self.get_single_link('items')
         if link is not None:
-            search = ItemSearch(link.href, method='GET')
+            search = ItemSearch(link.href, method='GET', stac_io=self.get_root()._stac_io)
             yield from search.get_items()
         else:
             yield from super().get_items()

--- a/tests/test_collection_client.py
+++ b/tests/test_collection_client.py
@@ -1,9 +1,10 @@
+from urllib.parse import urlsplit, parse_qs
 import pytest
 
 from pystac_client import CollectionClient
 from pystac_client.client import Client
 
-from .helpers import STAC_URLS
+from .helpers import STAC_URLS, read_data_file
 
 
 class TestCollectionClient:
@@ -22,3 +23,48 @@ class TestCollectionClient:
         for item in collection.get_items():
             assert (item.collection_id == collection.id)
             return
+
+    def test_custom_query_params(self, requests_mock):
+        """Checks that query params passed to the init method are added to requests."""
+        pc_root_text = read_data_file("planetary-computer-root.json")
+        pc_collection_dict = read_data_file("planetary-computer-collection.json", parse_json=True)
+
+        requests_mock.get(STAC_URLS["PLANETARY-COMPUTER"], status_code=200, text=pc_root_text)
+
+        init_qp_name = "my-param"
+        init_qp_value = "some-value"
+
+        client = Client.open(STAC_URLS['PLANETARY-COMPUTER'], parameters={init_qp_name: init_qp_value})
+
+        # Get the /collections endpoint
+        collections_link = client.get_single_link("data")
+
+        # Mock the request
+        requests_mock.get(collections_link.href,
+                          status_code=200,
+                          json={
+                              "collections": [pc_collection_dict],
+                              "links": []
+                          })
+
+        # Make the collections request
+        collection = next(client.get_collections())
+
+        # Mock the items endpoint
+        items_link = collection.get_single_link('items')
+        assert items_link is not None
+        requests_mock.get(items_link.href, status_code=200, json={"type": "FeatureCollection", "stac_version": "1.0.0", "features": [], "links": []})
+
+        # Make the items request
+        _ = list(collection.get_items())
+
+        history = requests_mock.request_history
+        assert len(history) == 3
+
+        actual_qs = urlsplit(history[2].url).query
+        actual_qp = parse_qs(actual_qs)
+
+        # Check that the query param from the root Client is present
+        assert init_qp_name in actual_qp
+        assert len(actual_qp[init_qp_name]) == 1
+        assert actual_qp[init_qp_name][0] == init_qp_value

--- a/tests/test_collection_client.py
+++ b/tests/test_collection_client.py
@@ -1,10 +1,9 @@
-from urllib.parse import urlsplit, parse_qs
 import pytest
 
 from pystac_client import CollectionClient
 from pystac_client.client import Client
 
-from .helpers import STAC_URLS, read_data_file
+from .helpers import STAC_URLS
 
 
 class TestCollectionClient:
@@ -23,48 +22,3 @@ class TestCollectionClient:
         for item in collection.get_items():
             assert (item.collection_id == collection.id)
             return
-
-    def test_custom_query_params(self, requests_mock):
-        """Checks that query params passed to the init method are added to requests."""
-        pc_root_text = read_data_file("planetary-computer-root.json")
-        pc_collection_dict = read_data_file("planetary-computer-collection.json", parse_json=True)
-
-        requests_mock.get(STAC_URLS["PLANETARY-COMPUTER"], status_code=200, text=pc_root_text)
-
-        init_qp_name = "my-param"
-        init_qp_value = "some-value"
-
-        client = Client.open(STAC_URLS['PLANETARY-COMPUTER'], parameters={init_qp_name: init_qp_value})
-
-        # Get the /collections endpoint
-        collections_link = client.get_single_link("data")
-
-        # Mock the request
-        requests_mock.get(collections_link.href,
-                          status_code=200,
-                          json={
-                              "collections": [pc_collection_dict],
-                              "links": []
-                          })
-
-        # Make the collections request
-        collection = next(client.get_collections())
-
-        # Mock the items endpoint
-        items_link = collection.get_single_link('items')
-        assert items_link is not None
-        requests_mock.get(items_link.href, status_code=200, json={"type": "FeatureCollection", "stac_version": "1.0.0", "features": [], "links": []})
-
-        # Make the items request
-        _ = list(collection.get_items())
-
-        history = requests_mock.request_history
-        assert len(history) == 3
-
-        actual_qs = urlsplit(history[2].url).query
-        actual_qp = parse_qs(actual_qs)
-
-        # Check that the query param from the root Client is present
-        assert init_qp_name in actual_qp
-        assert len(actual_qp[init_qp_name]) == 1
-        assert actual_qp[init_qp_name][0] == init_qp_value


### PR DESCRIPTION
**Related Issue(s):**

- Closes #125 

**Description:**

Ensures that query string parameters and headers given in `Client.open` or `Client.from_file` are used in requests from `CollectionClient` instances fetched from that API.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)