### PR TITLE
Allow providing filter-lang to search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `Client.search` accepts an optional `filter_lang` argument for `filter` requests [#128](https://github.com/stac-utils/pystac-client/pull/128)
+
 ### Fixed
 
 - Parameter formatting for GET searches in `ItemSearch.get_parameters` [#124](https://github.com/stac-utils/pystac-client/pull/124)

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -239,7 +239,7 @@ class ItemSearch:
 
         return query
 
-    def _format_filter_lang(self, filter: FilterLike, value: FilterLike) -> Optional[str]:
+    def _format_filter_lang(self, filter: FilterLike, value: FilterLangLike) -> Optional[str]:
         if filter is None:
             return None
 

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -41,6 +41,8 @@ IntersectsLike = Union[str, Intersects, object]
 Query = dict
 QueryLike = Union[Query, List[str]]
 
+FilterLangLike = str
+
 FilterLike = dict
 
 Sortby = List[str]
@@ -135,6 +137,7 @@ class ItemSearch:
             of the provided Collections will be searched
         query: List or JSON of query parameters as per the STAC API `query` extension
         filter: JSON of query parameters as per the STAC API `filter` extension
+        filter_lang: Language variant used in the filter body. Defaults to 'cql-json'.
         sortby: A single field or list of fields to sort the response by
         fields: A list of fields to return in the response. Note this may result in invalid JSON.
             Use `get_all_items_as_dict` to avoid errors
@@ -154,6 +157,7 @@ class ItemSearch:
                  collections: Optional[CollectionsLike] = None,
                  query: Optional[QueryLike] = None,
                  filter: Optional[FilterLike] = None,
+                 filter_lang: Optional[FilterLangLike] = None,
                  sortby: Optional[SortbyLike] = None,
                  fields: Optional[FieldsLike] = None,
                  max_items: Optional[int] = None,
@@ -187,12 +191,10 @@ class ItemSearch:
             'intersects': self._format_intersects(intersects),
             'query': self._format_query(query),
             'filter': self._format_filter(filter),
+            'filter-lang': self._format_filter_lang(filter, filter_lang),
             'sortby': self._format_sortby(sortby),
             'fields': self._format_fields(fields)
         }
-
-        if params['filter'] is not None:
-            params['filter-lang'] = 'cql-json'
 
         self._parameters = {k: v for k, v in params.items() if v is not None}
 
@@ -236,6 +238,15 @@ class ItemSearch:
             query = value
 
         return query
+
+    def _format_filter_lang(self, filter: FilterLike, value: FilterLike) -> Optional[str]:
+        if filter is None:
+            return None
+
+        if value is None:
+            return 'cql-json'
+
+        return value
 
     def _format_filter(self, value: FilterLike) -> Optional[dict]:
         if value is None:

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -260,6 +260,21 @@ class TestItemSearchParams:
         search = ItemSearch(url=SEARCH_URL, intersects=json.dumps(INTERSECTS_EXAMPLE))
         assert search._parameters['intersects'] == INTERSECTS_EXAMPLE
 
+    def test_filter_lang_default(self):
+        # No filter_lang specified
+        search = ItemSearch(url=SEARCH_URL, filter={})
+        assert search._parameters['filter-lang'] == 'cql-json'
+
+    def test_filter_lang(self):
+        # Use specified filter_lang
+        search = ItemSearch(url=SEARCH_URL, filter_lang="cql2-json", filter={})
+        assert search._parameters['filter-lang'] == 'cql2-json'
+
+    def test_filter_lang_without_filter(self):
+        # No filter provided
+        search = ItemSearch(url=SEARCH_URL)
+        assert 'filter-lang' not in search._parameters
+
 
 class TestItemSearch:
     @pytest.fixture(scope='function')


### PR DESCRIPTION
**Description:**

The user can optionally provide a filter-lang parameter to the
ItemSearch endpoint when using filter. This preserves the existing
behavior of defaulting to `cql-json` when no value is provided, so it
should be backwards compatible with existing code. By optionally
providing a new value, such as `cql2-json`, the user can supply filters
with different JSON language variants.

This change minimally anticipates the forthcoming STAC-API beta release
of the [filter fragment](https://github.com/radiantearth/stac-api-spec/tree/dev/fragments/filter) while preserving existing behavior. After the CQL2
changes are released in the next beta, it's likely we'll need a larger refactor
around supporting cql2-text, new conformance classes, etc. In the meantime,
this change will allow Planetary Computer users run cql2-json filters which are
supported in our pgstac implementation.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)