### PR TITLE
Allow only minor version dependency upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Allow only minor version updates to dependencies (`requests` and `pystac`) ([#132](https://github.com/stac-utils/pystac-client/pull/132)) 
+
 ## [v0.3.2] - 2022-01-11
 
 ### Added
 
-- `Client.search` accepts an optional `filter_lang` argument for `filter` requests [#128](https://github.com/stac-utils/pystac-client/pull/128)
+- `Client.search` accepts an optional `filter_lang` argument for `filter` requests ([#128](https://github.com/stac-utils/pystac-client/pull/128))
 
 ### Fixed
 - Values from `parameters` and `headers` arguments to `Client.open` and `Client.from_file` are now also used in requests made from `CollectionClient` instances

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ setup(
     include_package_data=False,
     python_requires=">=3.7",
     install_requires=[
-        "requests>=2.25",
-        "pystac~=1.2.0"
+        "requests~=2.25",
+        "pystac~=1.2"
     ],
     extras_require={
         "validation": ["jsonschema==3.2.0"]


### PR DESCRIPTION
**Related Issue(s):**

None

**Description:**

The version range for the PySTAC dependency (`pystac~=1.2.0`) only allowed for patch upgrades and the version range for `requests` (`requests>=2.25`) allowed for major version upgrades. Since both of these libraries have stable releases, it seems more appropriate to allow only minor version upgrades for both. This PR updates the version ranges in `setup.py` to implement this.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)