### PR TITLE
Add support for setting the filter language via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add `--filter-lang` parameter to allow specifying other filter language to be used within the `--filter` parameter
 
 ## [v0.3.2] - 2022-01-11
 

--- a/pystac_client/cli.py
+++ b/pystac_client/cli.py
@@ -101,8 +101,8 @@ def parse_args(args):
                               nargs='*',
                               help='Query properties of form '
                               'KEY=VALUE (<, >, <=, >=, = supported)')
-    search_group.add_argument('--filter',
-                              help='Filter on queryables using language specified in filter-lang parameter')
+    search_group.add_argument(
+        '--filter', help='Filter on queryables using language specified in filter-lang parameter')
     search_group.add_argument('--filter-lang',
                               help='Filter language used within the filter parameter',
                               default="cql-json")

--- a/pystac_client/cli.py
+++ b/pystac_client/cli.py
@@ -101,7 +101,11 @@ def parse_args(args):
                               nargs='*',
                               help='Query properties of form '
                               'KEY=VALUE (<, >, <=, >=, = supported)')
-    search_group.add_argument('--filter', help='Filter on queryables using CQL JSON')
+    search_group.add_argument('--filter',
+                              help='Filter on queryables using language specified in filter-lang parameter')
+    search_group.add_argument('--filter-lang',
+                              help='Filter language used within the filter parameter',
+                              default="cql-json")
     search_group.add_argument('--sortby', help='Sort by fields', nargs='*')
     search_group.add_argument('--fields', help='Control what fields get returned', nargs='*')
     search_group.add_argument('--limit', help='Page size limit', type=int, default=100)
@@ -147,7 +151,8 @@ def parse_args(args):
         parsed_args['headers'] = new_headers
 
     if 'filter' in parsed_args:
-        parsed_args['filter'] = json.loads(parsed_args['filter'])
+        if "json" in parsed_args["filter_lang"]:
+            parsed_args['filter'] = json.loads(parsed_args['filter'])
 
     return parsed_args
 


### PR DESCRIPTION
**Related Issue(s):** #139


**Description:** 

This PR add support for setting the filter language with a new cli parameter `--filter-lang`. If not set, it defaults to `cql-json`. This allows for using e.g. `cql-text` filter by specifying
```
--filter 'eo:cloud_cover < 60' 
--filter-lang "cql2-text"
```

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)