### PR TITLE
Add support for selecting the search endpoint using `media_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `Client.search` accepts an optional `filter_lang` argument for `filter` requests [#128](https://github.com/stac-utils/pystac-client/pull/128)
+- Added support for filtering the search endpoint using the `media_type` in `Client.open argument`. [#142](https://github.com/stac-utils/pystac-client/pull/142)
 
 ### Fixed
 - Values from `parameters` and `headers` arguments to `Client.open` and `Client.from_file` are now also used in requests made from `CollectionClient` instances

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - `Client.search` accepts an optional `filter_lang` argument for `filter` requests [#128](https://github.com/stac-utils/pystac-client/pull/128)
-- Added support for filtering the search endpoint using the `media_type` in `Client.open argument`. [#142](https://github.com/stac-utils/pystac-client/pull/142)
+- Added support for filtering the search endpoint using the `media_type` in `Client.open argument` [#142](https://github.com/stac-utils/pystac-client/pull/142)
 
 ### Fixed
 - Values from `parameters` and `headers` arguments to `Client.open` and `Client.from_file` are now also used in requests made from `CollectionClient` instances

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.3.2] - 2022-01-11
+## [v0.3.2] - 2022-01-11
 
 ### Added
 
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   fetched from the same API ([#126](https://github.com/stac-utils/pystac-client/pull/126))
 - The tests folder is no longer installed as a package.
 
-## [0.3.1] - 2021-11-17
+## [v0.3.1] - 2021-11-17
 
 ### Changed
 - Update min PySTAC version to 1.2
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Client.get_collections` raised an exception when API did not publish `/collections` conformance class instead of falling back to using child links
   [#120](https://github.com/stac-utils/pystac-client/pull/120)
 
-## [0.3.0] - 2021-09-28
+## [v0.3.0] - 2021-09-28
 
 ### Added
 - Jupyter Notebook tutorials

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -170,7 +170,7 @@ class Client(pystac.Catalog):
                 <https://github.com/radiantearth/stac-api-spec/tree/master/item-search>`__ or does not have a link with
                 a ``"rel"`` type of ``"search"``.
         """
-        search_link = self.get_single_link('search', media_type=media_type)
+        search_link = self.get_single_link('search', media_type=pystac.MediaType.GEOJSON)
         if search_link is None:
             raise NotImplementedError(
                 'No link with "rel" type of "search" could be found in this catalog')

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Dict, Optional, Union, TYPE_CHECKING
+from typing import Any, Iterable, Dict, Optional, TYPE_CHECKING
 
 import pystac
 import pystac.validation

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -33,7 +33,7 @@ class Client(pystac.Catalog):
         headers: Dict[str, str] = None,
         parameters: Optional[Dict[str, Any]] = None,
         ignore_conformance: bool = False,
-        media_type: Optional[Union[str, pystac.MediaType]] = None) -> "Client":
+    ) -> "Client":
         """Opens a STAC Catalog or API
         This function will read the root catalog of a STAC Catalog or API
 

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -40,7 +40,6 @@ class Client(pystac.Catalog):
         Args:
             url : The URL of a STAC Catalog. If not specified, this will use the `STAC_URL` environment variable.
             headers : A dictionary of additional headers to use in all requests made to any part of this Catalog/API.
-            media_type : Select search endpoint based on the specified `media_type`
             ignore_conformance : Ignore any advertised Conformance Classes in this Catalog/API. This means that
                 functions will skip checking conformance, and may throw an unknown error if that feature is
                 not supported, rather than a :class:`NotImplementedError`.

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -157,7 +157,6 @@ class Client(pystac.Catalog):
             If the API does not meet either of these criteria, this method will raise a :exc:`NotImplementedError`.
 
         Args:
-            media_type : Select search endpoint based on the specified `media_type`
             **kwargs : Any parameter to the :class:`~pystac_client.ItemSearch` class, other than `url`, `conformance`,
                 and `stac_io` which are set from this Client instance
 

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -143,9 +143,7 @@ class Client(pystac.Catalog):
         else:
             yield from super().get_items()
 
-    def search(self,
-               media_type: Optional[Union[str, pystac.MediaType]] = None,
-               **kwargs: Any) -> ItemSearch:
+    def search(self, **kwargs: Any) -> ItemSearch:
         """Query the ``/search`` endpoint using the given parameters.
 
         This method returns an :class:`~pystac_client.ItemSearch` instance, see that class's documentation

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -49,7 +49,7 @@ class Client(pystac.Catalog):
             catalog : A :class:`Client` instance for this Catalog/API
         """
         cat = cls.from_file(url, headers=headers, parameters=parameters)
-        search_link = cat.get_links('search', media_type=media_type)
+        search_link = cat.get_links('search', media_type=pystac.MediaType.GEOJSON)
         # if there is a search link, but no conformsTo advertised, ignore conformance entirely
         # NOTE: this behavior to be deprecated as implementations become conformant
         if ignore_conformance or ('conformsTo' not in cat.extra_fields.keys()


### PR DESCRIPTION
**Related Issue(s):** #

https://github.com/stac-utils/pystac/pull/704

**Description:**

Added support for selecting the search endpoint using the `media_type` argument to `get_single_link`.
This should fix interoperability STAC implementations, particularly with the STAC extension in GeoServer.

**PR Checklist:**

- [X] Code is formatted
- [X] Tests pass
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)