### PR TITLE
Relax PySTAC dependency

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,3 +32,41 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           fail_ci_if_error: false 
+
+  min-versions:
+    name: min-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+          cache: 'pip'
+          cache-dependency-path: 'requirements-min.txt'
+      - name: Install minimum requirements
+        run: pip install -r requirements-min.txt
+      - name: Install
+        run: pip install .
+      - name: Install dev requirements
+        run: pip install -r requirements-dev.txt
+      - name: Test
+        run: ./scripts/test
+
+  pre-release:
+    name: pre-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+          cache: 'pip'
+          cache-dependency-path: 'setup.py'
+      - name: Install
+        run: pip install .
+      - name: Install any pre-releases of pystac
+        run: pip install -U --pre pystac
+      - name: Install dev requirements
+        run: pip install -r requirements-dev.txt
+      - name: Test
+        run: ./scripts/test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,16 +17,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ hashFiles('requirements-dev.txt') }}
-          restore-keys: pip-
+          cache: 'pip'
+          cache-dependency-path: 'setup.py'
 
       - name: Execute linters and test suites
         run: ./scripts/cibuild

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- CI checks against minimum versions of all dependencies and any pre-release versions of PySTAC [#144](https://github.com/stac-utils/pystac-client/pull/144)
+
+### Changed
+
+- Relaxed upper bound on PySTAC dependency [#144](https://github.com/stac-utils/pystac-client/pull/144)
+
 ## [v0.3.2] - 2022-01-11
 
 ### Added

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,0 +1,3 @@
+requests==2.25
+pystac==1.2.0
+jsonschema==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "requests>=2.25",
-        "pystac~=1.2.0"
+        "pystac>=1.2.0"
     ],
     extras_require={
         "validation": ["jsonschema==3.2.0"]


### PR DESCRIPTION
**Related Issue(s):**
- Closes #138 
- Closes #113 

**Description:** Relaxes the PySTAC dependency to allow 1.3 (and above). Includes:
- Upgrades to setup-python@v3 and its built-in cache support
- Checks CI against any pre-release versions of PySTAC
- Checks CI against the minimum versions of all dependencies

See [this post](https://www.gadom.ski/2022/02/18/dependency-protection-with-python-and-github-actions.html) for some background on the CI setup.

**Note**: We may want to add `min-versions` and `pre-release` to the required checks for pull requests?

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)