### PR TITLE
Bump pystac to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Relaxed upper bound on PySTAC dependency [#144](https://github.com/stac-utils/pystac-client/pull/144)
+- Bumped PySTAC dependency to >= 1.4.0 [#147](https://github.com/stac-utils/pystac-client/pull/147)
 
 ## [v0.3.2] - 2022-01-11
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "requests>=2.25",
-        "pystac>=1.2.0"
+        "pystac>=1.4.0"
     ],
     extras_require={
         "validation": ["jsonschema==3.2.0"]


### PR DESCRIPTION
**Related Issue(s):**
- Unblocks #142 

**Description:**
As discussed https://github.com/stac-utils/pystac-client/pull/144#discussion_r848934819 and https://github.com/stac-utils/pystac-client/pull/142#issuecomment-1097467421, because PySTAC and pystac-client are so tightly coupled, we feel as though its ok for pystac-client to move to PySTAC 1.4 relatively quickly.


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)