### PR TITLE
Add dependency on python-dateutil

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,3 +1,4 @@
 requests==2.25
 pystac==1.2.0
 jsonschema==3.2.0
+python-dateutil==2.7.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "requests>=2.25",
-        "pystac>=1.4.0"
+        "pystac>=1.4.0",
+        "python-dateutil>=2.7.0",
     ],
     extras_require={
         "validation": ["jsonschema==3.2.0"]


### PR DESCRIPTION
`dateutil` is imported in https://github.com/stac-utils/pystac-client/blob/06ef534cdfcc6b11829799d9ec0cc17233ee2f7b/pystac_client/item_search.py#L1, but isn't declared as a dependency. 

This happens to work since pystac depends on python dateutil, but we should list it as a dependency anyway. I set it to match pystac's minimum bound from https://github.com/stac-utils/pystac/blob/a6c8927dfb1f1f92f60937b3022c499137416468/setup.py#L27