### PR TITLE
Relax search link requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Relaxed media type requirement for search links [#160](https://github.com/stac-utils/pystac-client/pull/160)
+
 ## [v0.3.3] - 2022-04-28
 
 ### Added

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ from urllib.parse import urlsplit, parse_qs
 from dateutil.tz import tzutc
 import pystac
 import pytest
+from pystac import MediaType
 
 from pystac_client import Client
 from pystac_client.conformance import ConformanceClasses
@@ -319,3 +320,11 @@ class TestAPISearch:
             'limit': 10,
             'datetime': '2020-01-01T00:00:00Z/..'
         }
+
+    def test_json_search_link(self, api: Client) -> None:
+        search_link = api.get_single_link(rel="search")
+        assert search_link
+        api.remove_links(rel="search")
+        search_link.media_type = MediaType.JSON
+        api.add_link(search_link)
+        api.search(limit=1, max_items=1, collections="naip")


### PR DESCRIPTION
**Related Issue(s):**
- Closes #159 
- Will unblock opendatacube/odc-stac#59


**Description:**
While "search" links are required to be media_type=GeoJSON by v1.0.0-rc.1 of the STAC-API spec, some older servers (e.g.
https://earth-search.aws.element84.com/v0/), use JSON. This patch adds a `require_geojson_link` parameter to both Client.open and Client.search. This parameter relaxes the media_type constraint in the default case, while allowing a user to opt-in to the stricter behavior if they would like.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)