### PR TITLE
Add py.typed to enable downstream type usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - lru_cache to several methods [#167](https://github.com/stac-utils/pystac-client/pull/167)
 - Direct item GET via ogcapi-features, if conformant [#166](https://github.com/stac-utils/pystac-client/pull/166)
+- `py.typed` for downstream type checking [#163](https://github.com/stac-utils/pystac-client/pull/163)
 
 ### Changed
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include *.typed

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     url="https://github.com/stac-utils/pystac-client.git",
     packages=find_packages(exclude=("tests",)),
     py_modules=[splitext(basename(path))[0] for path in glob("pystac_client/*.py")],
-    include_package_data=False,
+    include_package_data=True,
+    package_data={"pystac_client": ["py.typed"]},
     python_requires=">=3.7",
     install_requires=[
         "requests>=2.25",


### PR DESCRIPTION
**Related Issue(s):**
- Closes #143 

**Description:**

Based on the instructions at https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages. Manual checkout of downstream usage:

```sh
$ mkvirtualenv test-project >/dev/null 2>&1
$ pip install -U pip pystac-client mypy >/dev/null 2>&1
$ cat foo.py
from pystac_client.client import Client

id = 2
client = Client(id)
$ mypy foo.py
foo.py:1: error: Skipping analyzing "pystac_client.client": module is installed, but missing library stubs or py.typed marker
foo.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
$ pip uninstall -y pystac-client >/dev/null 2>&1
$ pip install 'git+https://github.com/stac-utils/pystac-client@issues/143-mypy-stubs' >/dev/null 2>&1
$ mypy foo.py
foo.py:4: error: Missing positional argument "description" in call to "Client"
foo.py:4: error: Argument 1 to "Client" has incompatible type "int"; expected "str"
Found 2 errors in 1 file (checked 1 source file)
```

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)