### PR TITLE
Check conformance before search links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - lru_cache to several methods [#167](https://github.com/stac-utils/pystac-client/pull/167)
 
+### Changed
+
+- Better error message when trying to search a non-item-search-conforming catalog [#164](https://github.com/stac-utils/pystac-client/pull/164)
+
 ## [v0.3.4] - 2022-05-18
 
 ### Changed

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -170,6 +170,9 @@ class Client(pystac.Catalog):
                 <https://github.com/radiantearth/stac-api-spec/tree/master/item-search>`__ or does not have a link with
                 a ``"rel"`` type of ``"search"``.
         """
+        if not self._stac_io.conforms_to(ConformanceClasses.ITEM_SEARCH):
+            raise NotImplementedError("This catalog does not support search because it "
+                                      f"does not conform to \"{ConformanceClasses.ITEM_SEARCH}\"")
         search_link = self.get_search_link()
         if search_link is None:
             raise NotImplementedError(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,7 @@
+import json
+import os.path
 from datetime import datetime
+from tempfile import TemporaryDirectory
 from urllib.parse import urlsplit, parse_qs
 
 from dateutil.tz import tzutc
@@ -306,6 +309,20 @@ class TestAPISearch:
         with pytest.raises(NotImplementedError) as excinfo:
             api.search(limit=10, max_items=10, collections='naip')
         assert 'No link with "rel" type of "search"' in str(excinfo.value)
+
+    def test_no_conforms_to(self):
+        with open(str(TEST_DATA / 'planetary-computer-root.json')) as f:
+            data = json.load(f)
+        del data["conformsTo"]
+        with TemporaryDirectory() as temporary_directory:
+            path = os.path.join(temporary_directory, "catalog.json")
+            with open(path, "w") as f:
+                json.dump(data, f)
+            api = Client.from_file(path)
+
+        with pytest.raises(NotImplementedError) as excinfo:
+            api.search(limit=10, max_items=10, collections='naip')
+        assert 'does not support search' in str(excinfo.value)
 
     def test_search(self, api):
         results = api.search(bbox=[-73.21, 43.99, -73.12, 44.05],


### PR DESCRIPTION
**Related Issue(s):**
- Closes #141 

**Description:** By checking conformance first, we can provide a more meaningful error message when, e.g., folks try to search a static catalog.

```sh
$ stac-client search ~/Code/stac-spec/examples/catalog.json
This catalog does not support search because it does not conform to "ConformanceClasses.ITEM_SEARCH"
```

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)