### PR TITLE
set filter-lang parameter correctly based on the filter parameter type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Relaxed upper bound on PySTAC dependency [#144](https://github.com/stac-utils/pystac-client/pull/144)
 - Bumped PySTAC dependency to >= 1.4.0 [#147](https://github.com/stac-utils/pystac-client/pull/147)
+- Search `filter-lang` defaults to `cql2-json` instead of `cql-json`
+- Search `filter-lang` will be set to `cql2-json` if the `filter` is a dict, or `cql2-text` if it is a string
+
+## Removed
+
+- Client parameter `require_geojson_link` has been removed.
 
 ## [v0.3.2] - 2022-01-11
 

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -142,7 +142,7 @@ class Client(pystac.Catalog):
         else:
             yield from super().get_items()
 
-    def search(self, require_geojson_link: bool = False, **kwargs: Any) -> ItemSearch:
+    def search(self, **kwargs: Any) -> ItemSearch:
         """Query the ``/search`` endpoint using the given parameters.
 
         This method returns an :class:`~pystac_client.ItemSearch` instance, see that class's documentation

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -138,7 +138,7 @@ class ItemSearch:
             of the provided Collections will be searched
         query: List or JSON of query parameters as per the STAC API `query` extension
         filter: JSON of query parameters as per the STAC API `filter` extension
-        filter_lang: Language variant used in the filter body. Defaults to 'cql2-json'.
+        filter_lang: Language variant used in the filter body. If `filter` is a dictionary or not provided, defaults to 'cql2-json'. If `filter` is a string, defaults to `cql2-text`.
         sortby: A single field or list of fields to sort the response by
         fields: A list of fields to return in the response. Note this may result in invalid JSON.
             Use `get_all_items_as_dict` to avoid errors

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -42,14 +42,15 @@ Query = dict
 QueryLike = Union[Query, List[str]]
 
 FilterLangLike = str
-
-FilterLike = dict
+FilterLike = Union[dict, str]
 
 Sortby = List[str]
 SortbyLike = Union[Sortby, str]
 
 Fields = List[str]
 FieldsLike = Union[Fields, str]
+
+OP_MAP = {'>=': 'gte', '<=': 'lte', '=': 'eq', '>': 'gt', '<': 'lt'}
 
 
 # from https://gist.github.com/angstwad/bf22d1822c38a92ec0a9#gistcomment-2622319
@@ -137,7 +138,7 @@ class ItemSearch:
             of the provided Collections will be searched
         query: List or JSON of query parameters as per the STAC API `query` extension
         filter: JSON of query parameters as per the STAC API `filter` extension
-        filter_lang: Language variant used in the filter body. Defaults to 'cql-json'.
+        filter_lang: Language variant used in the filter body. Defaults to 'cql2-json'.
         sortby: A single field or list of fields to sort the response by
         fields: A list of fields to return in the response. Note this may result in invalid JSON.
             Use `get_all_items_as_dict` to avoid errors
@@ -220,8 +221,6 @@ class ItemSearch:
         if value is None:
             return None
 
-        OP_MAP = {'>=': 'gte', '<=': 'lte', '=': 'eq', '>': 'gt', '<': 'lt'}
-
         if isinstance(value, list):
             query = {}
             for q in value:
@@ -239,14 +238,21 @@ class ItemSearch:
 
         return query
 
-    def _format_filter_lang(self, filter: FilterLike, value: FilterLangLike) -> Optional[str]:
-        if filter is None:
+    @staticmethod
+    def _format_filter_lang(_filter: FilterLike, value: FilterLangLike) -> Optional[str]:
+        if _filter is None:
             return None
 
-        if value is None:
-            return 'cql-json'
+        if value is not None:
+            return value
 
-        return value
+        if isinstance(_filter, str):
+            return 'cql2-text'
+
+        if isinstance(_filter, dict):
+            return 'cql2-json'
+
+        return None
 
     def _format_filter(self, value: FilterLike) -> Optional[dict]:
         if value is None:

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -260,14 +260,22 @@ class TestItemSearchParams:
         search = ItemSearch(url=SEARCH_URL, intersects=json.dumps(INTERSECTS_EXAMPLE))
         assert search._parameters['intersects'] == INTERSECTS_EXAMPLE
 
-    def test_filter_lang_default(self):
-        # No filter_lang specified
+    def test_filter_lang_default_for_dict(self):
         search = ItemSearch(url=SEARCH_URL, filter={})
-        assert search._parameters['filter-lang'] == 'cql-json'
+        assert search._parameters['filter-lang'] == 'cql2-json'
 
-    def test_filter_lang(self):
+    def test_filter_lang_default_for_str(self):
+        search = ItemSearch(url=SEARCH_URL, filter="")
+        assert search._parameters['filter-lang'] == 'cql2-text'
+
+    def test_filter_lang_cql2_text(self):
         # Use specified filter_lang
-        search = ItemSearch(url=SEARCH_URL, filter_lang="cql2-json", filter={})
+        search = ItemSearch(url=SEARCH_URL, filter_lang="cql2-text", filter={})
+        assert search._parameters['filter-lang'] == 'cql2-text'
+
+    def test_filter_lang_cql2_json(self):
+        # Use specified filter_lang
+        search = ItemSearch(url=SEARCH_URL, filter_lang="cql2-json", filter="")
         assert search._parameters['filter-lang'] == 'cql2-json'
 
     def test_filter_lang_without_filter(self):


### PR DESCRIPTION
**Related Issue(s):** #149

**Description:**

Set filter-lang to cql2-text if the filter paramater is a string, set it to cql2-json if it's a dict. 

**PR Checklist:**

- [X] Code is formatted
- [X] Tests pass
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)