### PR TITLE
clarify type requirements for search intersects parameter, update some documentation

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11-dev"
+#          - "3.11-dev"
     steps:
       - uses: actions/checkout@v3
 
@@ -28,16 +28,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'setup.py'
-
-      - uses: actions-rs/toolchain@v1
-        # Wheels for orjson are not available for Python 3.11. This sets up the Rust
-        # toolchain, so we can build orjson wheel from source.
-        if: ${{ startsWith(matrix.python-version, '3.11')}}
-        with:
-          toolchain: stable
-          override: true
-          default: true
-          profile: minimal
 
       - name: Execute linters and test suites
         run: ./scripts/cibuild

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
 #          - "3.11-dev"
         os:
           - ubuntu-latest
-          - windows-latest
+#          - windows-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,8 +11,14 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11-dev"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ jobs:
           - "3.10"
           - "3.11-dev"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
@@ -28,6 +28,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'setup.py'
+
+      - uses: actions-rs/toolchain@v1
+        # Wheels for orjson are not available for Python 3.11. This sets up the Rust
+        # toolchain, so we can build orjson wheel from source.
+        if: ${{ startsWith(matrix.python-version, '3.11')}}
+        with:
+          toolchain: stable
+          override: true
+          default: true
+          profile: minimal
 
       - name: Execute linters and test suites
         run: ./scripts/cibuild

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -19,6 +19,9 @@ jobs:
           - "3.9"
           - "3.10"
 #          - "3.11-dev"
+        os:
+          - ubuntu-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bumped PySTAC dependency to >= 1.4.0 [#147](https://github.com/stac-utils/pystac-client/pull/147)
 - Search `filter-lang` defaults to `cql2-json` instead of `cql-json`
 - Search `filter-lang` will be set to `cql2-json` if the `filter` is a dict, or `cql2-text` if it is a string
+- Search parameter `intersects` is now typed to only accept a str, dict, or object that implements `__geo_interface__`
 
 ## Removed
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-STAC Client
-===============
+# STAC Client <!-- omit in toc -->
 
 [![CI](https://github.com/stac-utils/pystac-client/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/stac-utils/pystac-client/actions/workflows/continuous-integration.yml)
 [![Release](https://github.com/stac-utils/pystac-client/actions/workflows/release.yml/badge.svg)](https://github.com/stac-utils/pystac-client/actions/workflows/release.yml)
@@ -9,6 +8,11 @@ STAC Client
 
 
 A Python client for working with [STAC](https://stacspec.org/) Catalogs and APIs.
+
+- [Installation](#installation)
+- [Documentation](#documentation)
+- [Development](#development)
+  - [Pull Requests](#pull-requests)
 
 ## Installation
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -129,7 +129,7 @@ The :meth:`pystac_client.Client.search` method provides an interface for making 
 .. code-block:: python
 
     >>> from pystac_client import API
-    >>> api = API.from_file('https://eod-catalog-svc-prod.astraea.earth')
+    >>> api = API.from_file('https://planetarycomputer.microsoft.com/api/stac/v1')
     >>> results = api.search(
     ...     bbox=[-73.21, 43.99, -73.12, 44.05],
     ...     datetime=['2019-01-01T00:00:00Z', '2019-01-02T00:00:00Z'],
@@ -169,7 +169,7 @@ implementation of this ``"next"`` link parsing assumes that the link follows the
 described in the `STAC API - Item Search: Paging <https://github.com/radiantearth/stac-api-spec/tree/master/item-search#paging>`__
 section. See the :mod:`Paging <pystac_client.paging>` docs for details on how to customize this behavior.
 
-Query Filter
+Query Extension
 ------------
 
 If the Catalog supports the `Query

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -22,12 +22,10 @@ DATETIME_REGEX = re.compile(r"(?P<year>\d{4})(\-(?P<month>\d{2})(\-(?P<day>\d{2}
                             r"(?P<remainder>(T|t)\d{2}:\d{2}:\d{2}(\.\d+)?"
                             r"(?P<tz_info>Z|([-+])(\d{2}):(\d{2}))?)?)?)?")
 
-
 # todo: add runtime_checkable when we drop 3.7 support
 # class GeoInterface(Protocol):
 #     def __geo_interface__(self) -> dict:
 #         ...
-
 
 DatetimeOrTimestamp = Optional[Union[datetime_, str]]
 Datetime = Union[Tuple[str], Tuple[str, str]]
@@ -44,7 +42,8 @@ IDs = Tuple[str, ...]
 IDsLike = Union[IDs, str, List[str], Iterator[str]]
 
 Intersects = dict
-IntersectsLike = Union[str, object, Intersects] #, GeoInterface]
+IntersectsLike = Union[str, object, Intersects]
+# todo: after 3.7 is dropped, replace object with GeoInterface
 
 Query = dict
 QueryLike = Union[Query, List[str]]

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -23,6 +23,7 @@ DATETIME_REGEX = re.compile(r"(?P<year>\d{4})(\-(?P<month>\d{2})(\-(?P<day>\d{2}
                             r"(?P<tz_info>Z|([-+])(\d{2}):(\d{2}))?)?)?)?")
 
 
+# todo: add runtime_checkable when
 class GeoInterface(Protocol):
     def __geo_interface__(self) -> dict:
         ...

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from datetime import timezone, datetime as datetime_
-from typing import Dict, Iterator, List, Optional, TYPE_CHECKING, Tuple, Union, Protocol
+from typing import Dict, Iterator, List, Optional, TYPE_CHECKING, Tuple, Union
 import warnings
 
 from pystac import Collection, Item, ItemCollection
@@ -24,9 +24,9 @@ DATETIME_REGEX = re.compile(r"(?P<year>\d{4})(\-(?P<month>\d{2})(\-(?P<day>\d{2}
 
 
 # todo: add runtime_checkable when we drop 3.7 support
-class GeoInterface(Protocol):
-    def __geo_interface__(self) -> dict:
-        ...
+# class GeoInterface(Protocol):
+#     def __geo_interface__(self) -> dict:
+#         ...
 
 
 DatetimeOrTimestamp = Optional[Union[datetime_, str]]
@@ -44,7 +44,7 @@ IDs = Tuple[str, ...]
 IDsLike = Union[IDs, str, List[str], Iterator[str]]
 
 Intersects = dict
-IntersectsLike = Union[str, Intersects, GeoInterface]
+IntersectsLike = Union[str, object, Intersects] #, GeoInterface]
 
 Query = dict
 QueryLike = Union[Query, List[str]]

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from datetime import timezone, datetime as datetime_
-from typing import Dict, Iterator, List, Optional, TYPE_CHECKING, Tuple, Union
+from typing import Dict, Iterator, List, Optional, TYPE_CHECKING, Tuple, Union, Protocol
 import warnings
 
 from pystac import Collection, Item, ItemCollection
@@ -21,6 +21,12 @@ if TYPE_CHECKING:
 DATETIME_REGEX = re.compile(r"(?P<year>\d{4})(\-(?P<month>\d{2})(\-(?P<day>\d{2})"
                             r"(?P<remainder>(T|t)\d{2}:\d{2}:\d{2}(\.\d+)?"
                             r"(?P<tz_info>Z|([-+])(\d{2}):(\d{2}))?)?)?)?")
+
+
+class GeoInterface(Protocol):
+    def __geo_interface__(self) -> dict:
+        ...
+
 
 DatetimeOrTimestamp = Optional[Union[datetime_, str]]
 Datetime = Union[Tuple[str], Tuple[str, str]]
@@ -37,7 +43,7 @@ IDs = Tuple[str, ...]
 IDsLike = Union[IDs, str, List[str], Iterator[str]]
 
 Intersects = dict
-IntersectsLike = Union[str, Intersects, object]
+IntersectsLike = Union[str, Intersects, GeoInterface]
 
 Query = dict
 QueryLike = Union[Query, List[str]]
@@ -132,7 +138,9 @@ class ItemSearch:
             - ``2017/2018`` expands to ``2017-01-01T00:00:00Z/2018-12-31T23:59:59Z``
             - ``2017-06/2017-07`` expands to ``2017-06-01T00:00:00Z/2017-07-31T23:59:59Z``
             - ``2017-06-10/2017-06-11`` expands to ``2017-06-10T00:00:00Z/2017-06-11T23:59:59Z``
-        intersects: A GeoJSON-like dictionary or JSON string. Results filtered to only those intersecting the geometry
+        intersects: A string or dictionary representing a GeoJSON geometry, or an object that implements a
+            ``__geo_interface__`` property as supported by several libraries including Shapely, ArcPy, PySAL, and
+            geojson. Results filtered to only those intersecting the geometry.
         ids: List of Item ids to return. All other filter parameters that further restrict the number of search results
             (except ``limit``) are ignored.
         collections: List of one or more Collection IDs or :class:`pystac.Collection` instances. Only Items in one
@@ -142,11 +150,11 @@ class ItemSearch:
         filter_lang: Language variant used in the filter body. If `filter` is a dictionary or not provided, defaults
             to 'cql2-json'. If `filter` is a string, defaults to `cql2-text`.
         sortby: A single field or list of fields to sort the response by
-        fields: A list of fields to return in the response. Note this may result in invalid JSON.
-            Use `get_all_items_as_dict` to avoid errors
-        max_items: The maximum number of items to get, even if there are more matched items
+        fields: A list of fields to include in the response. Note this may result in invalid STAC objects, as they
+            may not have required fields. Use `get_all_items_as_dict` to avoid object unmarshalling errors.
+        max_items: The maximum number of items to get, even if there are more matched items.
         method: The http method, 'GET' or 'POST'
-        stac_io: An instance of of StacIO for retrieving results. Normally comes from the Client that returns this ItemSearch
+        stac_io: An instance of StacIO for retrieving results. Normally comes from the Client that returns this ItemSearch
         client: An instance of a root Client used to set the root on resulting Items
     """
     def __init__(self,
@@ -409,9 +417,15 @@ class ItemSearch:
     def _format_intersects(value: Optional[IntersectsLike]) -> Optional[Intersects]:
         if value is None:
             return None
+        if isinstance(value, dict):
+            return deepcopy(value)
         if isinstance(value, str):
             return json.loads(value)
-        return deepcopy(getattr(value, '__geo_interface__', value))
+        if hasattr(value, '__geo_interface__'):
+            return deepcopy(getattr(value, '__geo_interface__'))
+        raise Exception(
+            "intersects must be of type None, str, dict, or an object that implements __geo_interface__"
+        )
 
     @lru_cache(1)
     def matched(self) -> int:

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -23,7 +23,7 @@ DATETIME_REGEX = re.compile(r"(?P<year>\d{4})(\-(?P<month>\d{2})(\-(?P<day>\d{2}
                             r"(?P<tz_info>Z|([-+])(\d{2}):(\d{2}))?)?)?)?")
 
 
-# todo: add runtime_checkable when
+# todo: add runtime_checkable when we drop 3.7 support
 class GeoInterface(Protocol):
     def __geo_interface__(self) -> dict:
         ...

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
         "Natural Language :: English",
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
         "Natural Language :: English",
         "Development Status :: 3 - Alpha",

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -260,6 +260,10 @@ class TestItemSearchParams:
         search = ItemSearch(url=SEARCH_URL, intersects=json.dumps(INTERSECTS_EXAMPLE))
         assert search._parameters['intersects'] == INTERSECTS_EXAMPLE
 
+    def test_intersects_non_geo_interface_object(self):
+        with pytest.raises(Exception):
+            ItemSearch(url=SEARCH_URL, intersects=object())
+
     def test_filter_lang_default_for_dict(self):
         search = ItemSearch(url=SEARCH_URL, filter={})
         assert search._parameters['filter-lang'] == 'cql2-json'
@@ -377,7 +381,9 @@ class TestItemSearch:
 
         # Geo-interface object
         class MockGeoObject:
-            __geo_interface__ = intersects_dict
+            @property
+            def __geo_interface__(self):
+                return intersects_dict
 
         intersects_obj = MockGeoObject()
         search = ItemSearch(url=SEARCH_URL, intersects=intersects_obj, collections='naip')


### PR DESCRIPTION
**Related Issue(s):** #146 


**Description:**

1. For search intersects, tighten type definitions to require str, dict, or object with __geo_interface__ attribute. Other objects now fail. If a user wants to use another object, they have to str() it first.
2. add better documentation about this.


**PR Checklist:**

- [X] Code is formatted
- [X] Tests pass
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)