### PR TITLE
deprecate get_all_items_as_dict and get_all_items, add get_items_as_dicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Deprecated
 
-- Item Search methods `get_all_items` and `get_all_items_as_dict` are now deprecated.
+- Item Search methods `get_all_items` and `get_all_items_as_dict` are now deprecated,
+  and may be removed as early as v0.5.0.
   These have been deprecated because they have the potential to perform a large number
   of requests to the server and instantiate a large number of objects in memory.
   To a user, this is only visible as a large delay in the method call and/or the
   exhaustion of all available memory. The iterator methods `get_items` or
-  `get_itemcollections` should be used instead. [#206](https://github.com/stac-utils/pystac-client/pull/206)
+  `get_item_collections` should be used instead. [#206](https://github.com/stac-utils/pystac-client/pull/206)
 
 ### Added
 
@@ -131,7 +132,7 @@ are in a single HTTP session, handle pagination and respects conformance
 - Update to use PySTAC 1.1.0
 - IO changed to use PySTAC's new StacIO base class. 
 - `Search.item_collections()` renamed to `Search.get_item_collections()`
-- `Search.item_collections()` renamed to `Search.get_items()`
+- `Search.item()` renamed to `Search.get_items()`
 - Conformance is checked by each individual function that requires a particular conformance
 - STAC API testing URLs changed to updated APIs
 - `ItemSearch.get_pages()` function moved to StacApiIO class for general use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   of requests to the server and instantiate a large number of objects in memory.
   To a user, this is only visible as a large delay in the method call and/or the
   exhaustion of all available memory. The iterator methods `get_items` or
-  `get_itemcollections` should be used instead.
+  `get_itemcollections` should be used instead. [#206](https://github.com/stac-utils/pystac-client/pull/206)
 
 ### Added
 
@@ -24,9 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Better error message when trying to search a non-item-search-conforming catalog [#164](https://github.com/stac-utils/pystac-client/pull/164)
-- Search `filter-lang` defaults to `cql2-json` instead of `cql-json`
-- Search `filter-lang` will be set to `cql2-json` if the `filter` is a dict, or `cql2-text` if it is a string
-- Search parameter `intersects` is now typed to only accept a str, dict, or object that implements `__geo_interface__`
+- Search `filter-lang` defaults to `cql2-json` instead of `cql-json` [#169](https://github.com/stac-utils/pystac-client/pull/169)
+- Search `filter-lang` will be set to `cql2-json` if the `filter` is a dict, or `cql2-text` if it is a string [#169](https://github.com/stac-utils/pystac-client/pull/169)
+- Search parameter `intersects` is now typed to only accept a str, dict, or object that implements `__geo_interface__` [#169](https://github.com/stac-utils/pystac-client/pull/169)
 
 ### Fixed
 
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Removed
 
-- Client parameter `require_geojson_link` has been removed.
+- Client parameter `require_geojson_link` has been removed. [#169](https://github.com/stac-utils/pystac-client/pull/169)
 
 ## [v0.3.5] - 2022-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased] - TBD
 
+### Deprecated
+
+- Item Search methods `get_all_items` and `get_all_items_as_dict` are now deprecated.
+  These have been deprecated because they have the potential to perform a large number
+  of requests to the server and instantiate a large number of objects in memory.
+  To a user, this is only visible as a large delay in the method call and/or the
+  exhaustion of all available memory. The iterator methods `get_items` or
+  `get_itemcollections` should be used instead.
+
 ### Added
 
 - lru_cache to several methods [#167](https://github.com/stac-utils/pystac-client/pull/167)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Deprecated
 
-- Item Search methods `get_all_items` and `get_all_items_as_dict` are now deprecated,
+- Item Search methods `get_items()` and `get_item_collections()` have been renamed to
+  `items()` and `item_collections()`. The original methods are now deprecated 
+  and may be removed as early as v0.5.0. [#206](https://github.com/stac-utils/pystac-client/pull/206)
+- Item Search methods `get_all_items()` and `get_all_items_as_dict()` are now deprecated,
   and may be removed as early as v0.5.0.
   These have been deprecated because they have the potential to perform a large number
   of requests to the server and instantiate a large number of objects in memory.
   To a user, this is only visible as a large delay in the method call and/or the
-  exhaustion of all available memory. The iterator methods `get_items` or
-  `get_item_collections` should be used instead. [#206](https://github.com/stac-utils/pystac-client/pull/206)
+  exhaustion of all available memory. The iterator methods `items()` or
+  `item_collections()` should be used instead. [#206](https://github.com/stac-utils/pystac-client/pull/206)
 
 ### Added
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -106,11 +106,11 @@ Create a search:
     my_search = catalog_client.search(collections=['sentinel-s2-l2a-cogs'], bbox=[-72.5,40.5,-72,41], max_items=10)
     print(f"{mysearch.matched()} items found")
 
-The ``get_items`` generator function can be used to iterate through all resulting items.
+The ``items()`` generator method can be used to iterate through all resulting items.
 
 .. code-block:: python
 
-    for item in my_search.get_items():
+    for item in my_search.items():
         print(item.id)
 
 To convert all of Items from a search as a single `PySTAC
@@ -125,5 +125,5 @@ Save all found items as a single FeatureCollection:
 
     from pystac import ItemCollection
 
-    my_itemcollection = ItemCollection(items = list(my_search.get_items()))
+    my_itemcollection = ItemCollection(items = list(my_search.items()))
     my_itemcollection.save_object('my_itemcollection.json')

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -13,7 +13,7 @@ The ``--matched`` switch performs a search with limit=1 so does not get
 any Items, but gets the total number of matches which will be output to
 the screen (if supported by the STAC API).
 
-::
+.. code-block:: console
 
     $ stac-client search https://earth-search.aws.element84.com/v0 -c sentinel-s2-l2a-cogs --bbox -72.5 40.5 -72 41 --matched
     2179 items matched
@@ -21,7 +21,7 @@ the screen (if supported by the STAC API).
 If the same URL is to be used over and over, define an environment
 variable to be used in the CLI call:
 
-::
+.. code-block:: console
 
     $ export STAC_API_URL=https://earth-search.aws.element84.com/v0
     $ stac-client search ${STAC_API_URL} -c sentinel-s2-l2a-cogs --bbox -72.5 40.5 -72 41 --datetime 2020-01-01/2020-01-31 --matched
@@ -36,7 +36,7 @@ another process such as
 `geojsonio-cli <https://github.com/mapbox/geojsonio-cli>`__, or
 `jq <https://stedolan.github.io/jq/>`__.
 
-::
+.. code-block:: console
 
     $ stac-client search ${STAC_API_URL} -c sentinel-s2-l2a-cogs --bbox -72.5 40.5 -72 41 --datetime 2020-01-01/2020-01-31 | stacterm cal --label platform
 
@@ -46,7 +46,7 @@ another process such as
 If the ``--save`` switch is provided instead, the results will not be
 output to stdout, but instead will be saved to the specified file.
 
-::
+.. code-block:: console
 
     $ stac-client search ${STAC_API_URL} -c sentinel-s2-l2a-cogs --bbox -72.5 40.5 -72 41 --datetime 2020-01-01/2020-01-31 --save items.json
 
@@ -77,12 +77,12 @@ The query filter will also accept complete JSON as per the specification.
 Any number of properties can be included, and each can be included more
 than once to use additional operators.
 
-::
+.. code-block:: console
 
     $ stac-client search ${STAC_API_URL} -c sentinel-s2-l2a-cogs --bbox -72.5 40.5 -72 41 --datetime 2020-01-01/2020-01-31 -q "eo:cloud_cover<10" --matched
     10 items matched
 
-::
+.. code-block:: console
 
     $ stac-client search ${STAC_API_URL} -c sentinel-s2-l2a-cogs --bbox -72.5 40.5 -72 41 --datetime 2020-01-01/2020-01-31 -q "eo:cloud_cover<10" "eo:cloud_cover>5" --matched
     4 items matched
@@ -91,37 +91,39 @@ Python
 ~~~~~~
 
 To use the Python library, first a Client instance is created for a
-specific STAC API (use the root URL)
+specific STAC API (use the root URL):
 
-::
+.. code-block:: python
 
     from pystac_client import Client
 
-    catalog = Client.open("https://earth-search.aws.element84.com/v0")
+    catalog_client = Client.open("https://earth-search.aws.element84.com/v0")
 
-Create a search
+Create a search:
 
-::
+.. code-block:: python
 
-    mysearch = catalog.search(collections=['sentinel-s2-l2a-cogs'], bbox=[-72.5,40.5,-72,41], max_items=10)
+    my_search = catalog_client.search(collections=['sentinel-s2-l2a-cogs'], bbox=[-72.5,40.5,-72,41], max_items=10)
     print(f"{mysearch.matched()} items found")
 
-The ``get_items`` function returns an iterator for looping through he
-returned items.
+The ``get_items`` generator function can be used to iterate through all resulting items.
 
-::
+.. code-block:: python
 
-    for item in mysearch.get_items():
+    for item in my_search.get_items():
         print(item.id)
 
-To get all of Items from a search as a single `PySTAC
-ItemCollection <https://pystac.readthedocs.io/en/latest/api.html#itemcollection>`__
-use the ``get_all_items`` function. The ``ItemCollection`` can then be
-saved as a GeoJSON FeatureCollection.
+To convert all of Items from a search as a single `PySTAC
+ItemCollection <https://pystac.readthedocs.io/en/latest/api/pystac.html#pystac.ItemCollection>`__,
+you must first do a limited iteration on the iterator to get a list of Items, and then
+create an ItemCollection with that. The ``ItemCollection`` can then be saved as a
+GeoJSON FeatureCollection.
 
-Save all found items as a single FeatureCollection
+Save all found items as a single FeatureCollection:
 
-::
+.. code-block:: python
 
-    items = mysearch.get_all_items()
-    items.save_object('items.json')
+    from pystac import ItemCollection
+
+    my_itemcollection = ItemCollection(items = list(my_search.get_items()))
+    my_itemcollection.save_object('my_itemcollection.json')

--- a/docs/tutorials/cql2-filter.ipynb
+++ b/docs/tutorials/cql2-filter.ipynb
@@ -5,7 +5,7 @@
    "id": "e06a27bf",
    "metadata": {},
    "source": [
-    "# pystac-client CQL Filtering\n",
+    "# pystac-client CQL2 Filtering\n",
     "\n",
     "This notebook demonstrates the use of pystac-client to use [CQL2 filtering](https://github.com/radiantearth/stac-api-spec/tree/master/fragments/filter). The server needs to support this and advertise conformance as the `https://api.stacspec.org/v1.0.0-rc.1/item-search#filter` class in the `conformsTo` attribute of the root API.\n",
     "\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "b65de617",
    "metadata": {},
    "outputs": [],
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "98942e75",
    "metadata": {},
    "outputs": [],
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "d8af6334",
    "metadata": {},
    "outputs": [],
@@ -125,7 +125,7 @@
     "    # limit sets the # of items per page so we can see multiple pages getting fetched\n",
     "    params['filter'] = filt\n",
     "    search = cat.search(**params)\n",
-    "    items = list(search.get_items_as_dicts()) # safe b/c we set max_items = 100\n",
+    "    items = list(search.items_as_dicts()) # safe b/c we set max_items = 100\n",
     "    # DataFrame\n",
     "    items_df = pd.DataFrame(items_to_geodataframe(items))\n",
     "    print(f\"{len(items_df.index)} items found\")\n",
@@ -145,24 +145,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "dfc0e759",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "'Item' object is not subscriptable",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m/var/folders/3q/jbg6x0zx3194zq6_2jbwygjw0000gn/T/ipykernel_73465/2658164751.py\u001b[0m in \u001b[0;36m<cell line: 6>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      4\u001b[0m }\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 6\u001b[0;31m \u001b[0msearch_fetch_plot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mparams\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfilt\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/var/folders/3q/jbg6x0zx3194zq6_2jbwygjw0000gn/T/ipykernel_73465/1512843940.py\u001b[0m in \u001b[0;36msearch_fetch_plot\u001b[0;34m(params, filt)\u001b[0m\n\u001b[1;32m     46\u001b[0m     \u001b[0mitems\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtake\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m100\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msearch\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_items\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     47\u001b[0m     \u001b[0;31m# DataFrame\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 48\u001b[0;31m     \u001b[0mitems_df\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDataFrame\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitems_to_geodataframe\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     49\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"{len(items_df.index)} items found\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     50\u001b[0m     \u001b[0mfield\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'properties.eo:cloud_cover'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/var/folders/3q/jbg6x0zx3194zq6_2jbwygjw0000gn/T/ipykernel_73465/3732288798.py\u001b[0m in \u001b[0;36mitems_to_geodataframe\u001b[0;34m(items)\u001b[0m\n\u001b[1;32m     18\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mitems\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m         \u001b[0m_i\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdeepcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 20\u001b[0;31m         \u001b[0m_i\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'geometry'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mshape\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_i\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'geometry'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     21\u001b[0m         \u001b[0m_items\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_i\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     22\u001b[0m     \u001b[0mgdf\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mGeoDataFrame\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjson_normalize\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_items\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: 'Item' object is not subscriptable"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "filt = {\n",
     "    \"op\": \"lte\",\n",
@@ -177,64 +163,7 @@
    "execution_count": null,
    "id": "9c2f9ca1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "92 items found\n"
-     ]
-    },
-    {
-     "data": {},
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.holoviews_exec.v0+json": "",
-      "text/html": [
-       "<div id='2474'>\n",
-       "  <div class=\"bk-root\" id=\"088eaa9a-7cf3-4325-bef5-b614fd538b2f\" data-root-id=\"2474\"></div>\n",
-       "</div>\n",
-       "<script type=\"application/javascript\">(function(root) {\n",
-       "  function embed_document(root) {\n",
-       "    var docs_json = {\"e0358105-14d3-4b74-860d-2c1c9f3efac1\":{\"defs\":[{\"extends\":null,\"module\":null,\"name\":\"ReactiveHTML1\",\"overrides\":[],\"properties\":[]},{\"extends\":null,\"module\":null,\"name\":\"FlexBox1\",\"overrides\":[],\"properties\":[{\"default\":\"flex-start\",\"kind\":null,\"name\":\"align_content\"},{\"default\":\"flex-start\",\"kind\":null,\"name\":\"align_items\"},{\"default\":\"row\",\"kind\":null,\"name\":\"flex_direction\"},{\"default\":\"wrap\",\"kind\":null,\"name\":\"flex_wrap\"},{\"default\":\"flex-start\",\"kind\":null,\"name\":\"justify_content\"}]},{\"extends\":null,\"module\":null,\"name\":\"GridStack1\",\"overrides\":[],\"properties\":[{\"default\":\"warn\",\"kind\":null,\"name\":\"mode\"},{\"default\":null,\"kind\":null,\"name\":\"ncols\"},{\"default\":null,\"kind\":null,\"name\":\"nrows\"},{\"default\":true,\"kind\":null,\"name\":\"allow_resize\"},{\"default\":true,\"kind\":null,\"name\":\"allow_drag\"},{\"default\":[],\"kind\":null,\"name\":\"state\"}]},{\"extends\":null,\"module\":null,\"name\":\"click1\",\"overrides\":[],\"properties\":[{\"default\":\"\",\"kind\":null,\"name\":\"terminal_output\"},{\"default\":\"\",\"kind\":null,\"name\":\"debug_name\"},{\"default\":0,\"kind\":null,\"name\":\"clears\"}]},{\"extends\":null,\"module\":null,\"name\":\"NotificationAreaBase1\",\"overrides\":[],\"properties\":[{\"default\":\"bottom-right\",\"kind\":null,\"name\":\"position\"},{\"default\":0,\"kind\":null,\"name\":\"_clear\"}]},{\"extends\":null,\"module\":null,\"name\":\"NotificationArea1\",\"overrides\":[],\"properties\":[{\"default\":[],\"kind\":null,\"name\":\"notifications\"},{\"default\":\"bottom-right\",\"kind\":null,\"name\":\"position\"},{\"default\":0,\"kind\":null,\"name\":\"_clear\"},{\"default\":[{\"background\":\"#ffc107\",\"icon\":{\"className\":\"fas fa-exclamation-triangle\",\"color\":\"white\",\"tagName\":\"i\"},\"type\":\"warning\"},{\"background\":\"#007bff\",\"icon\":{\"className\":\"fas fa-info-circle\",\"color\":\"white\",\"tagName\":\"i\"},\"type\":\"info\"}],\"kind\":null,\"name\":\"types\"}]},{\"extends\":null,\"module\":null,\"name\":\"Notification\",\"overrides\":[],\"properties\":[{\"default\":null,\"kind\":null,\"name\":\"background\"},{\"default\":3000,\"kind\":null,\"name\":\"duration\"},{\"default\":null,\"kind\":null,\"name\":\"icon\"},{\"default\":\"\",\"kind\":null,\"name\":\"message\"},{\"default\":null,\"kind\":null,\"name\":\"notification_type\"},{\"default\":false,\"kind\":null,\"name\":\"_destroyed\"}]},{\"extends\":null,\"module\":null,\"name\":\"TemplateActions1\",\"overrides\":[],\"properties\":[{\"default\":0,\"kind\":null,\"name\":\"open_modal\"},{\"default\":0,\"kind\":null,\"name\":\"close_modal\"}]},{\"extends\":null,\"module\":null,\"name\":\"MaterialTemplateActions1\",\"overrides\":[],\"properties\":[{\"default\":0,\"kind\":null,\"name\":\"open_modal\"},{\"default\":0,\"kind\":null,\"name\":\"close_modal\"}]}],\"roots\":{\"references\":[{\"attributes\":{\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2517\",\"type\":\"Line\"},{\"attributes\":{\"axis\":{\"id\":\"2492\"},\"coordinates\":null,\"dimension\":1,\"grid_line_color\":null,\"group\":null,\"ticker\":null},\"id\":\"2495\",\"type\":\"Grid\"},{\"attributes\":{\"below\":[{\"id\":\"2488\"}],\"center\":[{\"id\":\"2491\"},{\"id\":\"2495\"}],\"frame_height\":500,\"frame_width\":800,\"height\":null,\"left\":[{\"id\":\"2492\"}],\"margin\":[5,5,5,5],\"min_border_bottom\":10,\"min_border_left\":10,\"min_border_right\":10,\"min_border_top\":10,\"renderers\":[{\"id\":\"2515\"}],\"sizing_mode\":\"fixed\",\"title\":{\"id\":\"2480\"},\"toolbar\":{\"id\":\"2502\"},\"width\":null,\"x_range\":{\"id\":\"2476\"},\"x_scale\":{\"id\":\"2484\"},\"y_range\":{\"id\":\"2477\"},\"y_scale\":{\"id\":\"2486\"}},\"id\":\"2479\",\"subtype\":\"Figure\",\"type\":\"Plot\"},{\"attributes\":{\"callback\":null,\"formatters\":{\"@{properties.datetime}\":\"datetime\",\"@{properties_full_stop_datetime}\":\"datetime\"},\"renderers\":[{\"id\":\"2515\"}],\"tags\":[\"hv_created\"],\"tooltips\":[[\"properties.datetime\",\"@{properties_full_stop_datetime}{%F %T}\"],[\"properties.eo:cloud_cover\",\"@{properties_full_stop_eo_colon_cloud_cover}\"]]},\"id\":\"2478\",\"type\":\"HoverTool\"},{\"attributes\":{},\"id\":\"2523\",\"type\":\"AllLabels\"},{\"attributes\":{\"axis\":{\"id\":\"2488\"},\"coordinates\":null,\"grid_line_color\":null,\"group\":null,\"ticker\":null},\"id\":\"2491\",\"type\":\"Grid\"},{\"attributes\":{\"num_minor_ticks\":5,\"tickers\":[{\"id\":\"2534\"},{\"id\":\"2535\"},{\"id\":\"2536\"},{\"id\":\"2537\"},{\"id\":\"2538\"},{\"id\":\"2539\"},{\"id\":\"2540\"},{\"id\":\"2541\"},{\"id\":\"2542\"},{\"id\":\"2543\"},{\"id\":\"2544\"},{\"id\":\"2545\"}]},\"id\":\"2489\",\"type\":\"DatetimeTicker\"},{\"attributes\":{},\"id\":\"2519\",\"type\":\"DatetimeTickFormatter\"},{\"attributes\":{\"end\":101.998,\"reset_end\":101.998,\"reset_start\":78.02199999999999,\"start\":78.02199999999999,\"tags\":[[[\"properties.eo:cloud_cover\",\"properties.eo:cloud_cover\",null]]]},\"id\":\"2477\",\"type\":\"Range1d\"},{\"attributes\":{\"line_alpha\":0.1,\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2513\",\"type\":\"Line\"},{\"attributes\":{\"axis_label\":\"properties.eo:cloud_cover\",\"coordinates\":null,\"formatter\":{\"id\":\"2522\"},\"group\":null,\"major_label_policy\":{\"id\":\"2523\"},\"ticker\":{\"id\":\"2493\"}},\"id\":\"2492\",\"type\":\"LinearAxis\"},{\"attributes\":{},\"id\":\"2520\",\"type\":\"AllLabels\"},{\"attributes\":{\"coordinates\":null,\"group\":null,\"text\":\"{\\\"op\\\": \\\"gte\\\", \\\"args\\\": [{\\\"property\\\": \\\"eo:cloud_cover\\\"}, 80]}\",\"text_color\":\"black\",\"text_font_size\":\"12pt\"},\"id\":\"2480\",\"type\":\"Title\"},{\"attributes\":{},\"id\":\"2486\",\"type\":\"LinearScale\"},{\"attributes\":{\"data\":{\"properties.datetime\":{\"__ndarray__\":\"sPxnGZYPdkJedoxLexJ2Qq7bYFF7EnZCeww0bbwUdkKJtQhzvBR2Qi3UtaWhF3ZC+FsSIgkfdkI/weYnCR92QgJT91nuIXZCSrjLX+4hdkIQOhSY0yR2Qla+TLQUJ3ZC/NU41lUpdkJIOw3cVSl2Qgq1KA47LHZCVhr9EzssdkIQUPlnYTF2QpFxzW1hMXZC56cwQ+89dkLVrv191EB2QqBQCZwVQ3ZCdT3eoRVDdkII2ir2bVV2QkIUsxmvV3ZCJx0icdVcdkJ3gvZ21Vx2QqKFt7C6X3ZCpHhQZgdqdkKuISVsB2p2QpPsUo9IbHZCthdqR5V2dkJ/2OOM7Yh2Qss9uJLtiHZCkQk27hOOdkIItKsQVZB2QlyjS0k6k3ZCCBqoZXuVdkI3hxaeYJh2Qk4w66NgmHZCF+tyxqGadkInXfN17qR2QpyspLXTp3ZC0dAeMjuvdkLjefM3O692Qs3e6Y9htHZCrsu+lWG0dkL80+jJRrd2QtnAvc9Gt3ZC/sIu7Ye5dkJKKAPzh7l2QqZf6CZtvHZCf0y9LG28dkKYdvZJrr52Qufbyk+uvnZC8NfGg5PBdkIGgZuJk8F2QiGoUqfUw3ZCg6jevkfTdkJGIAgcbth2Qh8N3SFu2HZC1QTcsXngdkIlJljauuJ2QsvFMxOg5XZC7iK2L+HndkLHD4s14ed2QrYFlG7G6nZCgUd81V//dkLJrFDbX/92QtlusPegAXdCIdSE/aABd0Iz/4gwhgR3QkqoXTaGBHdCsru4WMcGd0IAegRvawd3QmI6YIusCXdCdeM0kawJd0Kcdpnl0g53QiGYbevSDndCi2ypu2Abd0K4Emsv+i93QgR4PzX6L3dClu9mb98yd0J5zfaMIDV3QmCtiYFSQndCd1Zeh1JCd0Jz9mQ8n0x3QkjjOUKfTHdCJ2WAX+BOd0IEUlVl4E53QnFn8ZjFUXdCfxDGnsVRd0Ip/pjBBlR3Qg==\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[92]},\"properties.eo:cloud_cover\":{\"__ndarray__\":\"AAAAAAAAWUCPwvUoXP9YQArXo3A9+lhAAAAAAAAAWUAAAAAAAABZQOF6FK5HAVRAFK5H4XqUVEBI4XoUrldUQI/C9Shc/1hAH4XrUbj+WECPwvUoXP9YQClcj8L12FdA16NwPQqXVkDXo3A9CjdWQK5H4XoU/lhArkfhehT+WEDsUbgehftYQAAAAAAAAFlAXI/C9Sj8WECamZmZmflVQAAAAAAAAFlAAAAAAAAAWUDsUbgehUtWQM3MzMzMPFZAj8L1KFz/WECamZmZmelYQD0K16NwHVdAXI/C9SiMVUDsUbgehftYQFK4HoXrEVdAzczMzMyMVkBI4XoUrjdYQArXo3A9+lhAuB6F61HoVkDhehSuR4FWQAAAAAAAAFlAPQrXo3D9WEAAAAAAAABZQAAAAAAAAFlAuB6F61EIWEBmZmZmZgZVQFK4HoXrQVRAMzMzMzPTWEB7FK5H4XpXQI/C9Shc/1hAMzMzMzNzVkAzMzMzM/NXQGZmZmZmxlZAMzMzMzPjWEB7FK5H4TpWQFyPwvUofFZAPQrXo3D9WEDsUbgehYtWQNejcD0KB1ZAAAAAAAAAWUBSuB6F67FXQD0K16NwPVdAw/UoXI8yVEAfhetRuP5YQAAAAAAA4FdAUrgeheuhWEDXo3A9CsdVQFyPwvUo3FZASOF6FK7nWEAK16NwPVpUQOxRuB6F+1hAAAAAAAAAWUAAAAAAAABZQKRwPQrXQ1dApHA9CtcjVUAAAAAAAABZQFyPwvUo/FhAcT0K16PgV0AAAAAAAABZQIXrUbgedVRAw/UoXI9yV0AAAAAAAABZQI/C9Shcz1ZAmpmZmZlZVECPwvUoXJ9VQM3MzMzMvFZAAAAAAADgV0AK16NwPbpUQHE9Ctej4FhAj8L1KFz/WECkcD0K1xNYQNejcD0Kt1hAAAAAAAAAWUCuR+F6FP5YQB+F61G4XlZAexSuR+H6VUC4HoXrUThXQA==\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[92]},\"properties_full_stop_datetime\":{\"__ndarray__\":\"sPxnGZYPdkJedoxLexJ2Qq7bYFF7EnZCeww0bbwUdkKJtQhzvBR2Qi3UtaWhF3ZC+FsSIgkfdkI/weYnCR92QgJT91nuIXZCSrjLX+4hdkIQOhSY0yR2Qla+TLQUJ3ZC/NU41lUpdkJIOw3cVSl2Qgq1KA47LHZCVhr9EzssdkIQUPlnYTF2QpFxzW1hMXZC56cwQ+89dkLVrv191EB2QqBQCZwVQ3ZCdT3eoRVDdkII2ir2bVV2QkIUsxmvV3ZCJx0icdVcdkJ3gvZ21Vx2QqKFt7C6X3ZCpHhQZgdqdkKuISVsB2p2QpPsUo9IbHZCthdqR5V2dkJ/2OOM7Yh2Qss9uJLtiHZCkQk27hOOdkIItKsQVZB2QlyjS0k6k3ZCCBqoZXuVdkI3hxaeYJh2Qk4w66NgmHZCF+tyxqGadkInXfN17qR2QpyspLXTp3ZC0dAeMjuvdkLjefM3O692Qs3e6Y9htHZCrsu+lWG0dkL80+jJRrd2QtnAvc9Gt3ZC/sIu7Ye5dkJKKAPzh7l2QqZf6CZtvHZCf0y9LG28dkKYdvZJrr52Qufbyk+uvnZC8NfGg5PBdkIGgZuJk8F2QiGoUqfUw3ZCg6jevkfTdkJGIAgcbth2Qh8N3SFu2HZC1QTcsXngdkIlJljauuJ2QsvFMxOg5XZC7iK2L+HndkLHD4s14ed2QrYFlG7G6nZCgUd81V//dkLJrFDbX/92QtlusPegAXdCIdSE/aABd0Iz/4gwhgR3QkqoXTaGBHdCsru4WMcGd0IAegRvawd3QmI6YIusCXdCdeM0kawJd0Kcdpnl0g53QiGYbevSDndCi2ypu2Abd0K4Emsv+i93QgR4PzX6L3dClu9mb98yd0J5zfaMIDV3QmCtiYFSQndCd1Zeh1JCd0Jz9mQ8n0x3QkjjOUKfTHdCJ2WAX+BOd0IEUlVl4E53QnFn8ZjFUXdCfxDGnsVRd0Ip/pjBBlR3Qg==\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[92]},\"properties_full_stop_eo_colon_cloud_cover\":{\"__ndarray__\":\"AAAAAAAAWUCPwvUoXP9YQArXo3A9+lhAAAAAAAAAWUAAAAAAAABZQOF6FK5HAVRAFK5H4XqUVEBI4XoUrldUQI/C9Shc/1hAH4XrUbj+WECPwvUoXP9YQClcj8L12FdA16NwPQqXVkDXo3A9CjdWQK5H4XoU/lhArkfhehT+WEDsUbgehftYQAAAAAAAAFlAXI/C9Sj8WECamZmZmflVQAAAAAAAAFlAAAAAAAAAWUDsUbgehUtWQM3MzMzMPFZAj8L1KFz/WECamZmZmelYQD0K16NwHVdAXI/C9SiMVUDsUbgehftYQFK4HoXrEVdAzczMzMyMVkBI4XoUrjdYQArXo3A9+lhAuB6F61HoVkDhehSuR4FWQAAAAAAAAFlAPQrXo3D9WEAAAAAAAABZQAAAAAAAAFlAuB6F61EIWEBmZmZmZgZVQFK4HoXrQVRAMzMzMzPTWEB7FK5H4XpXQI/C9Shc/1hAMzMzMzNzVkAzMzMzM/NXQGZmZmZmxlZAMzMzMzPjWEB7FK5H4TpWQFyPwvUofFZAPQrXo3D9WEDsUbgehYtWQNejcD0KB1ZAAAAAAAAAWUBSuB6F67FXQD0K16NwPVdAw/UoXI8yVEAfhetRuP5YQAAAAAAA4FdAUrgeheuhWEDXo3A9CsdVQFyPwvUo3FZASOF6FK7nWEAK16NwPVpUQOxRuB6F+1hAAAAAAAAAWUAAAAAAAABZQKRwPQrXQ1dApHA9CtcjVUAAAAAAAABZQFyPwvUo/FhAcT0K16PgV0AAAAAAAABZQIXrUbgedVRAw/UoXI9yV0AAAAAAAABZQI/C9Shcz1ZAmpmZmZlZVECPwvUoXJ9VQM3MzMzMvFZAAAAAAADgV0AK16NwPbpUQHE9Ctej4FhAj8L1KFz/WECkcD0K1xNYQNejcD0Kt1hAAAAAAAAAWUCuR+F6FP5YQB+F61G4XlZAexSuR+H6VUC4HoXrUThXQA==\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[92]}},\"selected\":{\"id\":\"2510\"},\"selection_policy\":{\"id\":\"2531\"}},\"id\":\"2509\",\"type\":\"ColumnDataSource\"},{\"attributes\":{\"source\":{\"id\":\"2509\"}},\"id\":\"2516\",\"type\":\"CDSView\"},{\"attributes\":{},\"id\":\"2497\",\"type\":\"PanTool\"},{\"attributes\":{},\"id\":\"2522\",\"type\":\"BasicTickFormatter\"},{\"attributes\":{},\"id\":\"2531\",\"type\":\"UnionRenderers\"},{\"attributes\":{\"base\":24,\"mantissas\":[1,2,4,6,8,12],\"max_interval\":43200000.0,\"min_interval\":3600000.0,\"num_minor_ticks\":0},\"id\":\"2536\",\"type\":\"AdaptiveTicker\"},{\"attributes\":{\"base\":60,\"mantissas\":[1,2,5,10,15,20,30],\"max_interval\":1800000.0,\"min_interval\":1000.0,\"num_minor_ticks\":0},\"id\":\"2535\",\"type\":\"AdaptiveTicker\"},{\"attributes\":{\"mantissas\":[1,2,5],\"max_interval\":500.0,\"num_minor_ticks\":0},\"id\":\"2534\",\"type\":\"AdaptiveTicker\"},{\"attributes\":{\"axis_label\":\"properties.datetime\",\"coordinates\":null,\"formatter\":{\"id\":\"2519\"},\"group\":null,\"major_label_policy\":{\"id\":\"2520\"},\"ticker\":{\"id\":\"2489\"}},\"id\":\"2488\",\"type\":\"DatetimeAxis\"},{\"attributes\":{\"tools\":[{\"id\":\"2478\"},{\"id\":\"2496\"},{\"id\":\"2497\"},{\"id\":\"2498\"},{\"id\":\"2499\"},{\"id\":\"2500\"}]},\"id\":\"2502\",\"type\":\"Toolbar\"},{\"attributes\":{},\"id\":\"2545\",\"type\":\"YearsTicker\"},{\"attributes\":{\"months\":[0,1,2,3,4,5,6,7,8,9,10,11]},\"id\":\"2541\",\"type\":\"MonthsTicker\"},{\"attributes\":{\"margin\":[5,5,5,5],\"name\":\"HSpacer05394\",\"sizing_mode\":\"stretch_width\"},\"id\":\"2546\",\"type\":\"Spacer\"},{\"attributes\":{},\"id\":\"2510\",\"type\":\"Selection\"},{\"attributes\":{\"days\":[1,15]},\"id\":\"2540\",\"type\":\"DaysTicker\"},{\"attributes\":{\"days\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},\"id\":\"2537\",\"type\":\"DaysTicker\"},{\"attributes\":{\"days\":[1,4,7,10,13,16,19,22,25,28]},\"id\":\"2538\",\"type\":\"DaysTicker\"},{\"attributes\":{},\"id\":\"2493\",\"type\":\"BasicTicker\"},{\"attributes\":{\"days\":[1,8,15,22]},\"id\":\"2539\",\"type\":\"DaysTicker\"},{\"attributes\":{},\"id\":\"2498\",\"type\":\"WheelZoomTool\"},{\"attributes\":{\"months\":[0,6]},\"id\":\"2544\",\"type\":\"MonthsTicker\"},{\"attributes\":{},\"id\":\"2496\",\"type\":\"SaveTool\"},{\"attributes\":{\"months\":[0,2,4,6,8,10]},\"id\":\"2542\",\"type\":\"MonthsTicker\"},{\"attributes\":{\"overlay\":{\"id\":\"2501\"}},\"id\":\"2499\",\"type\":\"BoxZoomTool\"},{\"attributes\":{},\"id\":\"2500\",\"type\":\"ResetTool\"},{\"attributes\":{\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2512\",\"type\":\"Line\"},{\"attributes\":{\"months\":[0,4,8]},\"id\":\"2543\",\"type\":\"MonthsTicker\"},{\"attributes\":{\"margin\":[5,5,5,5],\"name\":\"HSpacer05393\",\"sizing_mode\":\"stretch_width\"},\"id\":\"2475\",\"type\":\"Spacer\"},{\"attributes\":{\"bottom_units\":\"screen\",\"coordinates\":null,\"fill_alpha\":0.5,\"fill_color\":\"lightgrey\",\"group\":null,\"left_units\":\"screen\",\"level\":\"overlay\",\"line_alpha\":1.0,\"line_color\":\"black\",\"line_dash\":[4,4],\"line_width\":2,\"right_units\":\"screen\",\"syncable\":false,\"top_units\":\"screen\"},\"id\":\"2501\",\"type\":\"BoxAnnotation\"},{\"attributes\":{\"end\":1603103627663.885,\"reset_end\":1603103627663.885,\"reset_start\":1516012410495.793,\"start\":1516012410495.793,\"tags\":[[[\"properties.datetime\",\"properties.datetime\",null]]]},\"id\":\"2476\",\"type\":\"Range1d\"},{\"attributes\":{\"line_alpha\":0.2,\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2514\",\"type\":\"Line\"},{\"attributes\":{\"children\":[{\"id\":\"2475\"},{\"id\":\"2479\"},{\"id\":\"2546\"}],\"margin\":[0,0,0,0],\"name\":\"Row05389\",\"tags\":[\"embedded\"]},\"id\":\"2474\",\"type\":\"Row\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"2509\"},\"glyph\":{\"id\":\"2512\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"2514\"},\"nonselection_glyph\":{\"id\":\"2513\"},\"selection_glyph\":{\"id\":\"2517\"},\"view\":{\"id\":\"2516\"}},\"id\":\"2515\",\"type\":\"GlyphRenderer\"},{\"attributes\":{},\"id\":\"2484\",\"type\":\"LinearScale\"}],\"root_ids\":[\"2474\"]},\"title\":\"Bokeh Application\",\"version\":\"2.4.3\"}};\n",
-       "    var render_items = [{\"docid\":\"e0358105-14d3-4b74-860d-2c1c9f3efac1\",\"root_ids\":[\"2474\"],\"roots\":{\"2474\":\"088eaa9a-7cf3-4325-bef5-b614fd538b2f\"}}];\n",
-       "    root.Bokeh.embed.embed_items_notebook(docs_json, render_items);\n",
-       "  }\n",
-       "  if (root.Bokeh !== undefined && root.Bokeh.Panel !== undefined) {\n",
-       "    embed_document(root);\n",
-       "  } else {\n",
-       "    var attempts = 0;\n",
-       "    var timer = setInterval(function(root) {\n",
-       "      if (root.Bokeh !== undefined && root.Bokeh.Panel !== undefined) {\n",
-       "        clearInterval(timer);\n",
-       "        embed_document(root);\n",
-       "      } else if (document.readyState == \"complete\") {\n",
-       "        attempts++;\n",
-       "        if (attempts > 200) {\n",
-       "          clearInterval(timer);\n",
-       "          console.log(\"Bokeh: ERROR: Unable to run BokehJS code because BokehJS library is missing\");\n",
-       "        }\n",
-       "      }\n",
-       "    }, 25, root)\n",
-       "  }\n",
-       "})(window);</script>"
-      ],
-      "text/plain": [
-       ":Curve   [properties.datetime]   (properties.eo:cloud_cover)"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {
-      "application/vnd.holoviews_exec.v0+json": {
-       "id": "2474"
-      }
-     },
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "filt = {\n",
     "    \"op\": \"gte\",\n",
@@ -249,64 +178,7 @@
    "execution_count": null,
    "id": "109f673c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "41 items found\n"
-     ]
-    },
-    {
-     "data": {},
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.holoviews_exec.v0+json": "",
-      "text/html": [
-       "<div id='2658'>\n",
-       "  <div class=\"bk-root\" id=\"122845ef-df32-4c0f-a1a8-49936057e9a4\" data-root-id=\"2658\"></div>\n",
-       "</div>\n",
-       "<script type=\"application/javascript\">(function(root) {\n",
-       "  function embed_document(root) {\n",
-       "    var docs_json = {\"fed87580-768c-462b-b33b-00c09f6d6a4f\":{\"defs\":[{\"extends\":null,\"module\":null,\"name\":\"ReactiveHTML1\",\"overrides\":[],\"properties\":[]},{\"extends\":null,\"module\":null,\"name\":\"FlexBox1\",\"overrides\":[],\"properties\":[{\"default\":\"flex-start\",\"kind\":null,\"name\":\"align_content\"},{\"default\":\"flex-start\",\"kind\":null,\"name\":\"align_items\"},{\"default\":\"row\",\"kind\":null,\"name\":\"flex_direction\"},{\"default\":\"wrap\",\"kind\":null,\"name\":\"flex_wrap\"},{\"default\":\"flex-start\",\"kind\":null,\"name\":\"justify_content\"}]},{\"extends\":null,\"module\":null,\"name\":\"GridStack1\",\"overrides\":[],\"properties\":[{\"default\":\"warn\",\"kind\":null,\"name\":\"mode\"},{\"default\":null,\"kind\":null,\"name\":\"ncols\"},{\"default\":null,\"kind\":null,\"name\":\"nrows\"},{\"default\":true,\"kind\":null,\"name\":\"allow_resize\"},{\"default\":true,\"kind\":null,\"name\":\"allow_drag\"},{\"default\":[],\"kind\":null,\"name\":\"state\"}]},{\"extends\":null,\"module\":null,\"name\":\"click1\",\"overrides\":[],\"properties\":[{\"default\":\"\",\"kind\":null,\"name\":\"terminal_output\"},{\"default\":\"\",\"kind\":null,\"name\":\"debug_name\"},{\"default\":0,\"kind\":null,\"name\":\"clears\"}]},{\"extends\":null,\"module\":null,\"name\":\"NotificationAreaBase1\",\"overrides\":[],\"properties\":[{\"default\":\"bottom-right\",\"kind\":null,\"name\":\"position\"},{\"default\":0,\"kind\":null,\"name\":\"_clear\"}]},{\"extends\":null,\"module\":null,\"name\":\"NotificationArea1\",\"overrides\":[],\"properties\":[{\"default\":[],\"kind\":null,\"name\":\"notifications\"},{\"default\":\"bottom-right\",\"kind\":null,\"name\":\"position\"},{\"default\":0,\"kind\":null,\"name\":\"_clear\"},{\"default\":[{\"background\":\"#ffc107\",\"icon\":{\"className\":\"fas fa-exclamation-triangle\",\"color\":\"white\",\"tagName\":\"i\"},\"type\":\"warning\"},{\"background\":\"#007bff\",\"icon\":{\"className\":\"fas fa-info-circle\",\"color\":\"white\",\"tagName\":\"i\"},\"type\":\"info\"}],\"kind\":null,\"name\":\"types\"}]},{\"extends\":null,\"module\":null,\"name\":\"Notification\",\"overrides\":[],\"properties\":[{\"default\":null,\"kind\":null,\"name\":\"background\"},{\"default\":3000,\"kind\":null,\"name\":\"duration\"},{\"default\":null,\"kind\":null,\"name\":\"icon\"},{\"default\":\"\",\"kind\":null,\"name\":\"message\"},{\"default\":null,\"kind\":null,\"name\":\"notification_type\"},{\"default\":false,\"kind\":null,\"name\":\"_destroyed\"}]},{\"extends\":null,\"module\":null,\"name\":\"TemplateActions1\",\"overrides\":[],\"properties\":[{\"default\":0,\"kind\":null,\"name\":\"open_modal\"},{\"default\":0,\"kind\":null,\"name\":\"close_modal\"}]},{\"extends\":null,\"module\":null,\"name\":\"MaterialTemplateActions1\",\"overrides\":[],\"properties\":[{\"default\":0,\"kind\":null,\"name\":\"open_modal\"},{\"default\":0,\"kind\":null,\"name\":\"close_modal\"}]}],\"roots\":{\"references\":[{\"attributes\":{},\"id\":\"2682\",\"type\":\"WheelZoomTool\"},{\"attributes\":{\"end\":62.933,\"reset_end\":62.933,\"reset_start\":38.417,\"start\":38.417,\"tags\":[[[\"properties.eo:cloud_cover\",\"properties.eo:cloud_cover\",null]]]},\"id\":\"2661\",\"type\":\"Range1d\"},{\"attributes\":{},\"id\":\"2681\",\"type\":\"PanTool\"},{\"attributes\":{},\"id\":\"2668\",\"type\":\"LinearScale\"},{\"attributes\":{\"margin\":[5,5,5,5],\"name\":\"HSpacer05831\",\"sizing_mode\":\"stretch_width\"},\"id\":\"2659\",\"type\":\"Spacer\"},{\"attributes\":{\"overlay\":{\"id\":\"2685\"}},\"id\":\"2683\",\"type\":\"BoxZoomTool\"},{\"attributes\":{\"mantissas\":[1,2,5],\"max_interval\":500.0,\"num_minor_ticks\":0},\"id\":\"2718\",\"type\":\"AdaptiveTicker\"},{\"attributes\":{\"end\":1599733649647.455,\"reset_end\":1599733649647.455,\"reset_start\":1519554420756.7722,\"start\":1519554420756.7722,\"tags\":[[[\"properties.datetime\",\"properties.datetime\",null]]]},\"id\":\"2660\",\"type\":\"Range1d\"},{\"attributes\":{\"margin\":[5,5,5,5],\"name\":\"HSpacer05832\",\"sizing_mode\":\"stretch_width\"},\"id\":\"2730\",\"type\":\"Spacer\"},{\"attributes\":{},\"id\":\"2684\",\"type\":\"ResetTool\"},{\"attributes\":{\"axis\":{\"id\":\"2672\"},\"coordinates\":null,\"grid_line_color\":null,\"group\":null,\"ticker\":null},\"id\":\"2675\",\"type\":\"Grid\"},{\"attributes\":{\"bottom_units\":\"screen\",\"coordinates\":null,\"fill_alpha\":0.5,\"fill_color\":\"lightgrey\",\"group\":null,\"left_units\":\"screen\",\"level\":\"overlay\",\"line_alpha\":1.0,\"line_color\":\"black\",\"line_dash\":[4,4],\"line_width\":2,\"right_units\":\"screen\",\"syncable\":false,\"top_units\":\"screen\"},\"id\":\"2685\",\"type\":\"BoxAnnotation\"},{\"attributes\":{\"base\":60,\"mantissas\":[1,2,5,10,15,20,30],\"max_interval\":1800000.0,\"min_interval\":1000.0,\"num_minor_ticks\":0},\"id\":\"2719\",\"type\":\"AdaptiveTicker\"},{\"attributes\":{\"callback\":null,\"formatters\":{\"@{properties.datetime}\":\"datetime\",\"@{properties_full_stop_datetime}\":\"datetime\"},\"renderers\":[{\"id\":\"2699\"}],\"tags\":[\"hv_created\"],\"tooltips\":[[\"properties.datetime\",\"@{properties_full_stop_datetime}{%F %T}\"],[\"properties.eo:cloud_cover\",\"@{properties_full_stop_eo_colon_cloud_cover}\"]]},\"id\":\"2662\",\"type\":\"HoverTool\"},{\"attributes\":{\"base\":24,\"mantissas\":[1,2,4,6,8,12],\"max_interval\":43200000.0,\"min_interval\":3600000.0,\"num_minor_ticks\":0},\"id\":\"2720\",\"type\":\"AdaptiveTicker\"},{\"attributes\":{\"line_alpha\":0.2,\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2698\",\"type\":\"Line\"},{\"attributes\":{},\"id\":\"2729\",\"type\":\"YearsTicker\"},{\"attributes\":{\"months\":[0,1,2,3,4,5,6,7,8,9,10,11]},\"id\":\"2725\",\"type\":\"MonthsTicker\"},{\"attributes\":{\"days\":[1,15]},\"id\":\"2724\",\"type\":\"DaysTicker\"},{\"attributes\":{\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2696\",\"type\":\"Line\"},{\"attributes\":{},\"id\":\"2707\",\"type\":\"AllLabels\"},{\"attributes\":{\"days\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},\"id\":\"2721\",\"type\":\"DaysTicker\"},{\"attributes\":{\"days\":[1,4,7,10,13,16,19,22,25,28]},\"id\":\"2722\",\"type\":\"DaysTicker\"},{\"attributes\":{\"days\":[1,8,15,22]},\"id\":\"2723\",\"type\":\"DaysTicker\"},{\"attributes\":{\"axis\":{\"id\":\"2676\"},\"coordinates\":null,\"dimension\":1,\"grid_line_color\":null,\"group\":null,\"ticker\":null},\"id\":\"2679\",\"type\":\"Grid\"},{\"attributes\":{\"months\":[0,6]},\"id\":\"2728\",\"type\":\"MonthsTicker\"},{\"attributes\":{\"below\":[{\"id\":\"2672\"}],\"center\":[{\"id\":\"2675\"},{\"id\":\"2679\"}],\"frame_height\":500,\"frame_width\":800,\"height\":null,\"left\":[{\"id\":\"2676\"}],\"margin\":[5,5,5,5],\"min_border_bottom\":10,\"min_border_left\":10,\"min_border_right\":10,\"min_border_top\":10,\"renderers\":[{\"id\":\"2699\"}],\"sizing_mode\":\"fixed\",\"title\":{\"id\":\"2664\"},\"toolbar\":{\"id\":\"2686\"},\"width\":null,\"x_range\":{\"id\":\"2660\"},\"x_scale\":{\"id\":\"2668\"},\"y_range\":{\"id\":\"2661\"},\"y_scale\":{\"id\":\"2670\"}},\"id\":\"2663\",\"subtype\":\"Figure\",\"type\":\"Plot\"},{\"attributes\":{\"months\":[0,2,4,6,8,10]},\"id\":\"2726\",\"type\":\"MonthsTicker\"},{\"attributes\":{},\"id\":\"2680\",\"type\":\"SaveTool\"},{\"attributes\":{},\"id\":\"2706\",\"type\":\"BasicTickFormatter\"},{\"attributes\":{\"months\":[0,4,8]},\"id\":\"2727\",\"type\":\"MonthsTicker\"},{\"attributes\":{\"num_minor_ticks\":5,\"tickers\":[{\"id\":\"2718\"},{\"id\":\"2719\"},{\"id\":\"2720\"},{\"id\":\"2721\"},{\"id\":\"2722\"},{\"id\":\"2723\"},{\"id\":\"2724\"},{\"id\":\"2725\"},{\"id\":\"2726\"},{\"id\":\"2727\"},{\"id\":\"2728\"},{\"id\":\"2729\"}]},\"id\":\"2673\",\"type\":\"DatetimeTicker\"},{\"attributes\":{\"axis_label\":\"properties.eo:cloud_cover\",\"coordinates\":null,\"formatter\":{\"id\":\"2706\"},\"group\":null,\"major_label_policy\":{\"id\":\"2707\"},\"ticker\":{\"id\":\"2677\"}},\"id\":\"2676\",\"type\":\"LinearAxis\"},{\"attributes\":{\"tools\":[{\"id\":\"2662\"},{\"id\":\"2680\"},{\"id\":\"2681\"},{\"id\":\"2682\"},{\"id\":\"2683\"},{\"id\":\"2684\"}]},\"id\":\"2686\",\"type\":\"Toolbar\"},{\"attributes\":{\"axis_label\":\"properties.datetime\",\"coordinates\":null,\"formatter\":{\"id\":\"2703\"},\"group\":null,\"major_label_policy\":{\"id\":\"2704\"},\"ticker\":{\"id\":\"2673\"}},\"id\":\"2672\",\"type\":\"DatetimeAxis\"},{\"attributes\":{\"coordinates\":null,\"group\":null,\"text\":\"{\\\"op\\\": \\\"and\\\", \\\"args\\\": [{\\\"op\\\": \\\"lte\\\", \\\"args\\\": [{\\\"property\\\": \\\"eo:cloud_cover\\\"}, 60]}, {\\\"op\\\": \\\"gte\\\", \\\"args\\\": [{\\\"property\\\": \\\"eo:cloud_cover\\\"}, 40]}]}\",\"text_color\":\"black\",\"text_font_size\":\"12pt\"},\"id\":\"2664\",\"type\":\"Title\"},{\"attributes\":{\"source\":{\"id\":\"2693\"}},\"id\":\"2700\",\"type\":\"CDSView\"},{\"attributes\":{\"data\":{\"properties.datetime\":{\"__ndarray__\":\"WkwBBsgcdkISTW7BhzZ2QtEqQseHNnZCBhWy6Mg4dkL2IB4grjt2Qs0wHfo7SHZCjW/Wu4hSdkJtJ94Tr1d2QhJj7AjhZHZC/lgJwy1vdkIIQp7AoZp2QhA0ytxFm3ZC7LPG0xSqdkLBoJvZFKp2QslOOBT6rHZCBtFrbCCydkL2lCet1MN2Qin8ZeG5xnZCP6U657nGdkInLYFnIc52QhnGzfgs1nZCPVh5W1PbdkLHr5l4lN12QtlYbn6U3XZC0YDUonr8dkJiVuRSxwZ3QqxASbPtC3dCpslKZzoWd0JxW9RPbCN3QsWCj62SKHdC1ytks5Iod0LhmDfX0yp3QrwCkmnfMndCj3bLkiA1d0ItAq3MBTh3QrLzcyksPXdC8twkR20/d0IIhvlMbT93Qvyf9aqTRHdCpMY533hHd0JI9w7leEd3Qg==\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[41]},\"properties.eo:cloud_cover\":{\"__ndarray__\":\"KVyPwvWIRkCPwvUoXE9MQLgehetR+EpAw/UoXI+CR0Bcj8L1KFxHQArXo3A9ikhA16NwPQoXSEAK16NwPQpMQArXo3A9SkdAexSuR+E6REBSuB6F61FJQOF6FK5HYU5AUrgehevxRkA9CtejcJ1GQK5H4XoULk5Aj8L1KFyPTEDNzMzMzCxOQFyPwvUofEtAj8L1KFyPREApXI/C9UhKQArXo3A9Ck1ASOF6FK7nTUBxPQrXo7BHQOxRuB6Fi0dAhetRuB5FRkCkcD0K10NHQBSuR+F6VEVAPQrXo3B9R0CamZmZmblJQNejcD0KN0ZAAAAAAAAASUDNzMzMzGxHQOxRuB6FS0hAAAAAAABgS0BmZmZmZmZOQFyPwvUofE1ACtejcD1KRUDD9Shcj2JOQHE9CtejUExAUrgehetxTkA9CtejcB1OQA==\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[41]},\"properties_full_stop_datetime\":{\"__ndarray__\":\"WkwBBsgcdkISTW7BhzZ2QtEqQseHNnZCBhWy6Mg4dkL2IB4grjt2Qs0wHfo7SHZCjW/Wu4hSdkJtJ94Tr1d2QhJj7AjhZHZC/lgJwy1vdkIIQp7AoZp2QhA0ytxFm3ZC7LPG0xSqdkLBoJvZFKp2QslOOBT6rHZCBtFrbCCydkL2lCet1MN2Qin8ZeG5xnZCP6U657nGdkInLYFnIc52QhnGzfgs1nZCPVh5W1PbdkLHr5l4lN12QtlYbn6U3XZC0YDUonr8dkJiVuRSxwZ3QqxASbPtC3dCpslKZzoWd0JxW9RPbCN3QsWCj62SKHdC1ytks5Iod0LhmDfX0yp3QrwCkmnfMndCj3bLkiA1d0ItAq3MBTh3QrLzcyksPXdC8twkR20/d0IIhvlMbT93Qvyf9aqTRHdCpMY533hHd0JI9w7leEd3Qg==\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[41]},\"properties_full_stop_eo_colon_cloud_cover\":{\"__ndarray__\":\"KVyPwvWIRkCPwvUoXE9MQLgehetR+EpAw/UoXI+CR0Bcj8L1KFxHQArXo3A9ikhA16NwPQoXSEAK16NwPQpMQArXo3A9SkdAexSuR+E6REBSuB6F61FJQOF6FK5HYU5AUrgehevxRkA9CtejcJ1GQK5H4XoULk5Aj8L1KFyPTEDNzMzMzCxOQFyPwvUofEtAj8L1KFyPREApXI/C9UhKQArXo3A9Ck1ASOF6FK7nTUBxPQrXo7BHQOxRuB6Fi0dAhetRuB5FRkCkcD0K10NHQBSuR+F6VEVAPQrXo3B9R0CamZmZmblJQNejcD0KN0ZAAAAAAAAASUDNzMzMzGxHQOxRuB6FS0hAAAAAAABgS0BmZmZmZmZOQFyPwvUofE1ACtejcD1KRUDD9Shcj2JOQHE9CtejUExAUrgehetxTkA9CtejcB1OQA==\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[41]}},\"selected\":{\"id\":\"2694\"},\"selection_policy\":{\"id\":\"2715\"}},\"id\":\"2693\",\"type\":\"ColumnDataSource\"},{\"attributes\":{\"line_alpha\":0.1,\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2697\",\"type\":\"Line\"},{\"attributes\":{},\"id\":\"2715\",\"type\":\"UnionRenderers\"},{\"attributes\":{},\"id\":\"2694\",\"type\":\"Selection\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"2693\"},\"glyph\":{\"id\":\"2696\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"2698\"},\"nonselection_glyph\":{\"id\":\"2697\"},\"selection_glyph\":{\"id\":\"2701\"},\"view\":{\"id\":\"2700\"}},\"id\":\"2699\",\"type\":\"GlyphRenderer\"},{\"attributes\":{},\"id\":\"2704\",\"type\":\"AllLabels\"},{\"attributes\":{},\"id\":\"2703\",\"type\":\"DatetimeTickFormatter\"},{\"attributes\":{\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2701\",\"type\":\"Line\"},{\"attributes\":{},\"id\":\"2677\",\"type\":\"BasicTicker\"},{\"attributes\":{},\"id\":\"2670\",\"type\":\"LinearScale\"},{\"attributes\":{\"children\":[{\"id\":\"2659\"},{\"id\":\"2663\"},{\"id\":\"2730\"}],\"margin\":[0,0,0,0],\"name\":\"Row05827\",\"tags\":[\"embedded\"]},\"id\":\"2658\",\"type\":\"Row\"}],\"root_ids\":[\"2658\"]},\"title\":\"Bokeh Application\",\"version\":\"2.4.3\"}};\n",
-       "    var render_items = [{\"docid\":\"fed87580-768c-462b-b33b-00c09f6d6a4f\",\"root_ids\":[\"2658\"],\"roots\":{\"2658\":\"122845ef-df32-4c0f-a1a8-49936057e9a4\"}}];\n",
-       "    root.Bokeh.embed.embed_items_notebook(docs_json, render_items);\n",
-       "  }\n",
-       "  if (root.Bokeh !== undefined && root.Bokeh.Panel !== undefined) {\n",
-       "    embed_document(root);\n",
-       "  } else {\n",
-       "    var attempts = 0;\n",
-       "    var timer = setInterval(function(root) {\n",
-       "      if (root.Bokeh !== undefined && root.Bokeh.Panel !== undefined) {\n",
-       "        clearInterval(timer);\n",
-       "        embed_document(root);\n",
-       "      } else if (document.readyState == \"complete\") {\n",
-       "        attempts++;\n",
-       "        if (attempts > 200) {\n",
-       "          clearInterval(timer);\n",
-       "          console.log(\"Bokeh: ERROR: Unable to run BokehJS code because BokehJS library is missing\");\n",
-       "        }\n",
-       "      }\n",
-       "    }, 25, root)\n",
-       "  }\n",
-       "})(window);</script>"
-      ],
-      "text/plain": [
-       ":Curve   [properties.datetime]   (properties.eo:cloud_cover)"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {
-      "application/vnd.holoviews_exec.v0+json": {
-       "id": "2658"
-      }
-     },
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "filt = { \n",
     "    \"op\": \"and\",\n",

--- a/docs/tutorials/cql2-filter.ipynb
+++ b/docs/tutorials/cql2-filter.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 8,
    "id": "b65de617",
    "metadata": {},
    "outputs": [],
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 9,
    "id": "98942e75",
    "metadata": {},
    "outputs": [],
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 10,
    "id": "d8af6334",
    "metadata": {},
    "outputs": [],
@@ -125,9 +125,9 @@
     "    # limit sets the # of items per page so we can see multiple pages getting fetched\n",
     "    params['filter'] = filt\n",
     "    search = cat.search(**params)\n",
-    "    items_json = search.get_all_items_as_dict()\n",
+    "    items = list(search.get_items_as_dicts()) # safe b/c we set max_items = 100\n",
     "    # DataFrame\n",
-    "    items_df = pd.DataFrame(items_to_geodataframe(items_json['features']))\n",
+    "    items_df = pd.DataFrame(items_to_geodataframe(items))\n",
     "    print(f\"{len(items_df.index)} items found\")\n",
     "    field = 'properties.eo:cloud_cover'\n",
     "    return items_df.hvplot(y=field, label=json.dumps(filt), frame_height=500, frame_width=800)    "
@@ -145,65 +145,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 11,
    "id": "dfc0e759",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "33 items found\n"
+     "ename": "TypeError",
+     "evalue": "'Item' object is not subscriptable",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/3q/jbg6x0zx3194zq6_2jbwygjw0000gn/T/ipykernel_73465/2658164751.py\u001b[0m in \u001b[0;36m<cell line: 6>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      4\u001b[0m }\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 6\u001b[0;31m \u001b[0msearch_fetch_plot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mparams\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfilt\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/var/folders/3q/jbg6x0zx3194zq6_2jbwygjw0000gn/T/ipykernel_73465/1512843940.py\u001b[0m in \u001b[0;36msearch_fetch_plot\u001b[0;34m(params, filt)\u001b[0m\n\u001b[1;32m     46\u001b[0m     \u001b[0mitems\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtake\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m100\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msearch\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_items\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     47\u001b[0m     \u001b[0;31m# DataFrame\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 48\u001b[0;31m     \u001b[0mitems_df\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDataFrame\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitems_to_geodataframe\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     49\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"{len(items_df.index)} items found\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     50\u001b[0m     \u001b[0mfield\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'properties.eo:cloud_cover'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/var/folders/3q/jbg6x0zx3194zq6_2jbwygjw0000gn/T/ipykernel_73465/3732288798.py\u001b[0m in \u001b[0;36mitems_to_geodataframe\u001b[0;34m(items)\u001b[0m\n\u001b[1;32m     18\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mitems\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m         \u001b[0m_i\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdeepcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 20\u001b[0;31m         \u001b[0m_i\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'geometry'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mshape\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_i\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'geometry'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     21\u001b[0m         \u001b[0m_items\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_i\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     22\u001b[0m     \u001b[0mgdf\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mGeoDataFrame\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjson_normalize\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_items\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: 'Item' object is not subscriptable"
      ]
-    },
-    {
-     "data": {},
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.holoviews_exec.v0+json": "",
-      "text/html": [
-       "<div id='2290'>\n",
-       "  <div class=\"bk-root\" id=\"692f9a51-db19-45fe-ba9e-81171d102e0e\" data-root-id=\"2290\"></div>\n",
-       "</div>\n",
-       "<script type=\"application/javascript\">(function(root) {\n",
-       "  function embed_document(root) {\n",
-       "    var docs_json = {\"b4f9bdcb-4b3b-411a-b906-58de74488c2c\":{\"defs\":[{\"extends\":null,\"module\":null,\"name\":\"ReactiveHTML1\",\"overrides\":[],\"properties\":[]},{\"extends\":null,\"module\":null,\"name\":\"FlexBox1\",\"overrides\":[],\"properties\":[{\"default\":\"flex-start\",\"kind\":null,\"name\":\"align_content\"},{\"default\":\"flex-start\",\"kind\":null,\"name\":\"align_items\"},{\"default\":\"row\",\"kind\":null,\"name\":\"flex_direction\"},{\"default\":\"wrap\",\"kind\":null,\"name\":\"flex_wrap\"},{\"default\":\"flex-start\",\"kind\":null,\"name\":\"justify_content\"}]},{\"extends\":null,\"module\":null,\"name\":\"GridStack1\",\"overrides\":[],\"properties\":[{\"default\":\"warn\",\"kind\":null,\"name\":\"mode\"},{\"default\":null,\"kind\":null,\"name\":\"ncols\"},{\"default\":null,\"kind\":null,\"name\":\"nrows\"},{\"default\":true,\"kind\":null,\"name\":\"allow_resize\"},{\"default\":true,\"kind\":null,\"name\":\"allow_drag\"},{\"default\":[],\"kind\":null,\"name\":\"state\"}]},{\"extends\":null,\"module\":null,\"name\":\"click1\",\"overrides\":[],\"properties\":[{\"default\":\"\",\"kind\":null,\"name\":\"terminal_output\"},{\"default\":\"\",\"kind\":null,\"name\":\"debug_name\"},{\"default\":0,\"kind\":null,\"name\":\"clears\"}]},{\"extends\":null,\"module\":null,\"name\":\"NotificationAreaBase1\",\"overrides\":[],\"properties\":[{\"default\":\"bottom-right\",\"kind\":null,\"name\":\"position\"},{\"default\":0,\"kind\":null,\"name\":\"_clear\"}]},{\"extends\":null,\"module\":null,\"name\":\"NotificationArea1\",\"overrides\":[],\"properties\":[{\"default\":[],\"kind\":null,\"name\":\"notifications\"},{\"default\":\"bottom-right\",\"kind\":null,\"name\":\"position\"},{\"default\":0,\"kind\":null,\"name\":\"_clear\"},{\"default\":[{\"background\":\"#ffc107\",\"icon\":{\"className\":\"fas fa-exclamation-triangle\",\"color\":\"white\",\"tagName\":\"i\"},\"type\":\"warning\"},{\"background\":\"#007bff\",\"icon\":{\"className\":\"fas fa-info-circle\",\"color\":\"white\",\"tagName\":\"i\"},\"type\":\"info\"}],\"kind\":null,\"name\":\"types\"}]},{\"extends\":null,\"module\":null,\"name\":\"Notification\",\"overrides\":[],\"properties\":[{\"default\":null,\"kind\":null,\"name\":\"background\"},{\"default\":3000,\"kind\":null,\"name\":\"duration\"},{\"default\":null,\"kind\":null,\"name\":\"icon\"},{\"default\":\"\",\"kind\":null,\"name\":\"message\"},{\"default\":null,\"kind\":null,\"name\":\"notification_type\"},{\"default\":false,\"kind\":null,\"name\":\"_destroyed\"}]},{\"extends\":null,\"module\":null,\"name\":\"TemplateActions1\",\"overrides\":[],\"properties\":[{\"default\":0,\"kind\":null,\"name\":\"open_modal\"},{\"default\":0,\"kind\":null,\"name\":\"close_modal\"}]},{\"extends\":null,\"module\":null,\"name\":\"MaterialTemplateActions1\",\"overrides\":[],\"properties\":[{\"default\":0,\"kind\":null,\"name\":\"open_modal\"},{\"default\":0,\"kind\":null,\"name\":\"close_modal\"}]}],\"roots\":{\"references\":[{\"attributes\":{},\"id\":\"2313\",\"type\":\"PanTool\"},{\"attributes\":{\"line_alpha\":0.2,\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2330\",\"type\":\"Line\"},{\"attributes\":{},\"id\":\"2347\",\"type\":\"UnionRenderers\"},{\"attributes\":{\"base\":60,\"mantissas\":[1,2,5,10,15,20,30],\"max_interval\":1800000.0,\"min_interval\":1000.0,\"num_minor_ticks\":0},\"id\":\"2351\",\"type\":\"AdaptiveTicker\"},{\"attributes\":{\"mantissas\":[1,2,5],\"max_interval\":500.0,\"num_minor_ticks\":0},\"id\":\"2350\",\"type\":\"AdaptiveTicker\"},{\"attributes\":{\"callback\":null,\"formatters\":{\"@{properties.datetime}\":\"datetime\",\"@{properties_full_stop_datetime}\":\"datetime\"},\"renderers\":[{\"id\":\"2331\"}],\"tags\":[\"hv_created\"],\"tooltips\":[[\"properties.datetime\",\"@{properties_full_stop_datetime}{%F %T}\"],[\"properties.eo:cloud_cover\",\"@{properties_full_stop_eo_colon_cloud_cover}\"]]},\"id\":\"2294\",\"type\":\"HoverTool\"},{\"attributes\":{},\"id\":\"2335\",\"type\":\"DatetimeTickFormatter\"},{\"attributes\":{\"days\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]},\"id\":\"2353\",\"type\":\"DaysTicker\"},{\"attributes\":{\"days\":[1,4,7,10,13,16,19,22,25,28]},\"id\":\"2354\",\"type\":\"DaysTicker\"},{\"attributes\":{},\"id\":\"2326\",\"type\":\"Selection\"},{\"attributes\":{\"base\":24,\"mantissas\":[1,2,4,6,8,12],\"max_interval\":43200000.0,\"min_interval\":3600000.0,\"num_minor_ticks\":0},\"id\":\"2352\",\"type\":\"AdaptiveTicker\"},{\"attributes\":{\"days\":[1,15]},\"id\":\"2356\",\"type\":\"DaysTicker\"},{\"attributes\":{},\"id\":\"2361\",\"type\":\"YearsTicker\"},{\"attributes\":{\"months\":[0,1,2,3,4,5,6,7,8,9,10,11]},\"id\":\"2357\",\"type\":\"MonthsTicker\"},{\"attributes\":{},\"id\":\"2309\",\"type\":\"BasicTicker\"},{\"attributes\":{\"data\":{\"properties.datetime\":{\"__ndarray__\":\"yfC9zeIZdkInMf97LyR2Qm+W04EvJHZC4R7kL3wudkIthLg1fC52QpYDuomiM3ZC4WiOj6IzdkIQbq2lRjR2Qq7rUtz6RXZCuAilV2JNdkLPsXldYk12QrrZZSwiZ3ZCzYI6MiJndkJ9o+blbnF2Qo9Mu+tucXZC0fBmry6LdkLjmTu1Lot2Qqz6V/mGnXZC+F8s/4addkJmwpwbyJ92QuzjcCHIn3ZC4UT5U62idkIKo2oHFBF3QovEPg0UEXdCKc5iI7gRd0IZ1Il93hZ3QuU+vpkfGXdCOaSSnx8Zd0IfSZfzRR53QoMEqVVsI3dCh5i2eK0ld0JqwM8LuS13QuX2IKWTRHdC\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[33]},\"properties.eo:cloud_cover\":{\"__ndarray__\":\"j8L1KFyPGkB7FK5H4XqUPwAAAAAAAOg/exSuR+F6lD8zMzMzMzPTPwAAAAAAAAAAZmZmZmZm1j/2KFyPwvUKQOF6FK5H4RxAmpmZmZmZAUCPwvUoXI/6P1K4HoXr0SFA9ihcj8L1FkCPwvUoXA8jQJqZmZmZmR1AmpmZmZmZEED2KFyPwvUZQFyPwvUoXCRAcT0K16Nw5T+kcD0K16McQAAAAAAAACNACtejcD0K1z+4HoXrUbieP0jhehSuR/U/mpmZmZmZ2T9xPQrXo3ANQIXrUbgehes/w/UoXI/C1T8UrkfhehQhQArXo3A9CiRA16NwPQrXGkAK16NwPQoJQFK4HoXrUQhA\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[33]},\"properties_full_stop_datetime\":{\"__ndarray__\":\"yfC9zeIZdkInMf97LyR2Qm+W04EvJHZC4R7kL3wudkIthLg1fC52QpYDuomiM3ZC4WiOj6IzdkIQbq2lRjR2Qq7rUtz6RXZCuAilV2JNdkLPsXldYk12QrrZZSwiZ3ZCzYI6MiJndkJ9o+blbnF2Qo9Mu+tucXZC0fBmry6LdkLjmTu1Lot2Qqz6V/mGnXZC+F8s/4addkJmwpwbyJ92QuzjcCHIn3ZC4UT5U62idkIKo2oHFBF3QovEPg0UEXdCKc5iI7gRd0IZ1Il93hZ3QuU+vpkfGXdCOaSSnx8Zd0IfSZfzRR53QoMEqVVsI3dCh5i2eK0ld0JqwM8LuS13QuX2IKWTRHdC\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[33]},\"properties_full_stop_eo_colon_cloud_cover\":{\"__ndarray__\":\"j8L1KFyPGkB7FK5H4XqUPwAAAAAAAOg/exSuR+F6lD8zMzMzMzPTPwAAAAAAAAAAZmZmZmZm1j/2KFyPwvUKQOF6FK5H4RxAmpmZmZmZAUCPwvUoXI/6P1K4HoXr0SFA9ihcj8L1FkCPwvUoXA8jQJqZmZmZmR1AmpmZmZmZEED2KFyPwvUZQFyPwvUoXCRAcT0K16Nw5T+kcD0K16McQAAAAAAAACNACtejcD0K1z+4HoXrUbieP0jhehSuR/U/mpmZmZmZ2T9xPQrXo3ANQIXrUbgehes/w/UoXI/C1T8UrkfhehQhQArXo3A9CiRA16NwPQrXGkAK16NwPQoJQFK4HoXrUQhA\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[33]}},\"selected\":{\"id\":\"2326\"},\"selection_policy\":{\"id\":\"2347\"}},\"id\":\"2325\",\"type\":\"ColumnDataSource\"},{\"attributes\":{},\"id\":\"2314\",\"type\":\"WheelZoomTool\"},{\"attributes\":{\"days\":[1,8,15,22]},\"id\":\"2355\",\"type\":\"DaysTicker\"},{\"attributes\":{\"months\":[0,6]},\"id\":\"2360\",\"type\":\"MonthsTicker\"},{\"attributes\":{},\"id\":\"2312\",\"type\":\"SaveTool\"},{\"attributes\":{\"months\":[0,2,4,6,8,10]},\"id\":\"2358\",\"type\":\"MonthsTicker\"},{\"attributes\":{\"axis_label\":\"properties.datetime\",\"coordinates\":null,\"formatter\":{\"id\":\"2335\"},\"group\":null,\"major_label_policy\":{\"id\":\"2336\"},\"ticker\":{\"id\":\"2305\"}},\"id\":\"2304\",\"type\":\"DatetimeAxis\"},{\"attributes\":{\"overlay\":{\"id\":\"2317\"}},\"id\":\"2315\",\"type\":\"BoxZoomTool\"},{\"attributes\":{\"end\":11.198,\"reset_end\":11.198,\"reset_start\":-1.018,\"start\":-1.018,\"tags\":[[[\"properties.eo:cloud_cover\",\"properties.eo:cloud_cover\",null]]]},\"id\":\"2293\",\"type\":\"Range1d\"},{\"attributes\":{},\"id\":\"2302\",\"type\":\"LinearScale\"},{\"attributes\":{},\"id\":\"2316\",\"type\":\"ResetTool\"},{\"attributes\":{\"months\":[0,4,8]},\"id\":\"2359\",\"type\":\"MonthsTicker\"},{\"attributes\":{\"margin\":[5,5,5,5],\"name\":\"HSpacer04955\",\"sizing_mode\":\"stretch_width\"},\"id\":\"2291\",\"type\":\"Spacer\"},{\"attributes\":{\"bottom_units\":\"screen\",\"coordinates\":null,\"fill_alpha\":0.5,\"fill_color\":\"lightgrey\",\"group\":null,\"left_units\":\"screen\",\"level\":\"overlay\",\"line_alpha\":1.0,\"line_color\":\"black\",\"line_dash\":[4,4],\"line_width\":2,\"right_units\":\"screen\",\"syncable\":false,\"top_units\":\"screen\"},\"id\":\"2317\",\"type\":\"BoxAnnotation\"},{\"attributes\":{\"axis\":{\"id\":\"2304\"},\"coordinates\":null,\"grid_line_color\":null,\"group\":null,\"ticker\":null},\"id\":\"2307\",\"type\":\"Grid\"},{\"attributes\":{\"end\":1598956392975.431,\"reset_end\":1598956392975.431,\"reset_start\":1518777195487.049,\"start\":1518777195487.049,\"tags\":[[[\"properties.datetime\",\"properties.datetime\",null]]]},\"id\":\"2292\",\"type\":\"Range1d\"},{\"attributes\":{},\"id\":\"2336\",\"type\":\"AllLabels\"},{\"attributes\":{\"tools\":[{\"id\":\"2294\"},{\"id\":\"2312\"},{\"id\":\"2313\"},{\"id\":\"2314\"},{\"id\":\"2315\"},{\"id\":\"2316\"}]},\"id\":\"2318\",\"type\":\"Toolbar\"},{\"attributes\":{\"children\":[{\"id\":\"2291\"},{\"id\":\"2295\"},{\"id\":\"2362\"}],\"margin\":[0,0,0,0],\"name\":\"Row04951\",\"tags\":[\"embedded\"]},\"id\":\"2290\",\"type\":\"Row\"},{\"attributes\":{},\"id\":\"2339\",\"type\":\"AllLabels\"},{\"attributes\":{\"margin\":[5,5,5,5],\"name\":\"HSpacer04956\",\"sizing_mode\":\"stretch_width\"},\"id\":\"2362\",\"type\":\"Spacer\"},{\"attributes\":{\"below\":[{\"id\":\"2304\"}],\"center\":[{\"id\":\"2307\"},{\"id\":\"2311\"}],\"frame_height\":500,\"frame_width\":800,\"height\":null,\"left\":[{\"id\":\"2308\"}],\"margin\":[5,5,5,5],\"min_border_bottom\":10,\"min_border_left\":10,\"min_border_right\":10,\"min_border_top\":10,\"renderers\":[{\"id\":\"2331\"}],\"sizing_mode\":\"fixed\",\"title\":{\"id\":\"2296\"},\"toolbar\":{\"id\":\"2318\"},\"width\":null,\"x_range\":{\"id\":\"2292\"},\"x_scale\":{\"id\":\"2300\"},\"y_range\":{\"id\":\"2293\"},\"y_scale\":{\"id\":\"2302\"}},\"id\":\"2295\",\"subtype\":\"Figure\",\"type\":\"Plot\"},{\"attributes\":{\"axis\":{\"id\":\"2308\"},\"coordinates\":null,\"dimension\":1,\"grid_line_color\":null,\"group\":null,\"ticker\":null},\"id\":\"2311\",\"type\":\"Grid\"},{\"attributes\":{},\"id\":\"2300\",\"type\":\"LinearScale\"},{\"attributes\":{\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2333\",\"type\":\"Line\"},{\"attributes\":{\"num_minor_ticks\":5,\"tickers\":[{\"id\":\"2350\"},{\"id\":\"2351\"},{\"id\":\"2352\"},{\"id\":\"2353\"},{\"id\":\"2354\"},{\"id\":\"2355\"},{\"id\":\"2356\"},{\"id\":\"2357\"},{\"id\":\"2358\"},{\"id\":\"2359\"},{\"id\":\"2360\"},{\"id\":\"2361\"}]},\"id\":\"2305\",\"type\":\"DatetimeTicker\"},{\"attributes\":{},\"id\":\"2338\",\"type\":\"BasicTickFormatter\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"2325\"},\"glyph\":{\"id\":\"2328\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"2330\"},\"nonselection_glyph\":{\"id\":\"2329\"},\"selection_glyph\":{\"id\":\"2333\"},\"view\":{\"id\":\"2332\"}},\"id\":\"2331\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"axis_label\":\"properties.eo:cloud_cover\",\"coordinates\":null,\"formatter\":{\"id\":\"2338\"},\"group\":null,\"major_label_policy\":{\"id\":\"2339\"},\"ticker\":{\"id\":\"2309\"}},\"id\":\"2308\",\"type\":\"LinearAxis\"},{\"attributes\":{\"coordinates\":null,\"group\":null,\"text\":\"{\\\"op\\\": \\\"lte\\\", \\\"args\\\": [{\\\"property\\\": \\\"eo:cloud_cover\\\"}, 10]}\",\"text_color\":\"black\",\"text_font_size\":\"12pt\"},\"id\":\"2296\",\"type\":\"Title\"},{\"attributes\":{\"line_alpha\":0.1,\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2329\",\"type\":\"Line\"},{\"attributes\":{\"line_color\":\"#30a2da\",\"line_width\":2,\"x\":{\"field\":\"properties.datetime\"},\"y\":{\"field\":\"properties.eo:cloud_cover\"}},\"id\":\"2328\",\"type\":\"Line\"},{\"attributes\":{\"source\":{\"id\":\"2325\"}},\"id\":\"2332\",\"type\":\"CDSView\"}],\"root_ids\":[\"2290\"]},\"title\":\"Bokeh Application\",\"version\":\"2.4.3\"}};\n",
-       "    var render_items = [{\"docid\":\"b4f9bdcb-4b3b-411a-b906-58de74488c2c\",\"root_ids\":[\"2290\"],\"roots\":{\"2290\":\"692f9a51-db19-45fe-ba9e-81171d102e0e\"}}];\n",
-       "    root.Bokeh.embed.embed_items_notebook(docs_json, render_items);\n",
-       "  }\n",
-       "  if (root.Bokeh !== undefined && root.Bokeh.Panel !== undefined) {\n",
-       "    embed_document(root);\n",
-       "  } else {\n",
-       "    var attempts = 0;\n",
-       "    var timer = setInterval(function(root) {\n",
-       "      if (root.Bokeh !== undefined && root.Bokeh.Panel !== undefined) {\n",
-       "        clearInterval(timer);\n",
-       "        embed_document(root);\n",
-       "      } else if (document.readyState == \"complete\") {\n",
-       "        attempts++;\n",
-       "        if (attempts > 200) {\n",
-       "          clearInterval(timer);\n",
-       "          console.log(\"Bokeh: ERROR: Unable to run BokehJS code because BokehJS library is missing\");\n",
-       "        }\n",
-       "      }\n",
-       "    }, 25, root)\n",
-       "  }\n",
-       "})(window);</script>"
-      ],
-      "text/plain": [
-       ":Curve   [properties.datetime]   (properties.eo:cloud_cover)"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {
-      "application/vnd.holoviews_exec.v0+json": {
-       "id": "2290"
-      }
-     },
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -217,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "9c2f9ca1",
    "metadata": {},
    "outputs": [
@@ -289,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "109f673c",
    "metadata": {},
    "outputs": [

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -159,13 +159,13 @@ requests to a service's "search" endpoint. This method returns a
 Instances of :class:`~pystac_client.ItemSearch` have 2 methods for iterating
 over results:
 
-* :meth:`ItemSearch.get_item_collections
-  <pystac_client.ItemSearch.get_item_collections>`: iterator over *pages* of results,
+* :meth:`ItemSearch.item_collections
+  <pystac_client.ItemSearch.item_collections>`: iterator over *pages* of results,
   yielding an :class:`~pystac.ItemCollection` for each page of results.
-* :meth:`ItemSearch.get_items <pystac_client.ItemSearch.get_items>`: an iterator over
+* :meth:`ItemSearch.items <pystac_client.ItemSearch.items>`: an iterator over
   individual Item objects, yielding a :class:`pystac.Item` instance for all Items
   that match the search criteria.
-* :meth:`ItemSearch.get_items_as_dicts <pystac_client.ItemSearch.get_items_as_dicts>`:
+* :meth:`ItemSearch.items_as_dicts <pystac_client.ItemSearch.items_as_dicts>`:
   iterate over individual results, yielding a :class:`dict` instance representing each
   item that matches the search criteria. This eliminates the overhead of creating
   class:`pystac.Item` objects
@@ -179,7 +179,7 @@ how many total items matched the query:
 
 .. code-block:: python
 
-    >>> for item in results.get_items():
+    >>> for item in results.items():
     ...     print(item.id)
     S2B_OPER_MSI_L2A_TL_SGS__20190101T200120_A009518_T18TXP_N02.11
     MCD43A4.A2019010.h12v04.006.2019022234410
@@ -187,7 +187,7 @@ how many total items matched the query:
     MYD11A1.A2019002.h12v04.006.2019003174703
     MYD11A1.A2019001.h12v04.006.2019002165238
 
-The :meth:`~pystac_client.ItemSearch.get_items` and related methods handle retrieval of
+The :meth:`~pystac_client.ItemSearch.items` and related methods handle retrieval of
 successive pages of results
 by finding links with a ``"rel"`` type of ``"next"`` and parsing them to construct the
 next request. The default
@@ -203,7 +203,7 @@ ItemCollection is one page of results retrieved from search:
 
 .. code-block:: python
 
-    >>> for ic in results.get_item_collections():
+    >>> for ic in results.item_collections():
     ...     for item in ic.items:
     ...         print(item.id)
     S2B_OPER_MSI_L2A_TL_SGS__20190101T200120_A009518_T18TXP_N02.11
@@ -213,13 +213,13 @@ ItemCollection is one page of results retrieved from search:
     MYD11A1.A2019001.h12v04.006.2019002165238
 
 If you do not need the :class:`pystac.Item` instances, you can instead use
-:meth:`ItemSearch.get_items_as_dicts <pystac_client.ItemSearch.get_items_as_dicts>`
-to retrive dictionary representation of the items, without incurring the cost of
+:meth:`ItemSearch.items_as_dicts <pystac_client.ItemSearch.items_as_dicts>`
+to retrieve dictionary representation of the items, without incurring the cost of
 creating the Item objects.
 
 .. code-block:: python
 
-    >>> for item_dict in results.get_items_as_dicts():
+    >>> for item_dict in results.items_as_dicts():
     ...     print(item_dict["id"])
     S2B_OPER_MSI_L2A_TL_SGS__20190101T200120_A009518_T18TXP_N02.11
     MCD43A4.A2019010.h12v04.006.2019022234410

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -168,7 +168,7 @@ over results:
 * :meth:`ItemSearch.get_items_as_dicts <pystac_client.ItemSearch.get_items_as_dicts>`:
   iterate over individual results, yielding a :class:`dict` instance representing each
   item that matches the search criteria. This eliminates the overhead of creating
-  class:`pystac.Item` objects with pydantic
+  class:`pystac.Item` objects
 
 Additionally, the ``matched`` method can be used to access result metadata about
 how many total items matched the query:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -215,7 +215,7 @@ ItemCollection is one page of results retrieved from search:
 If you do not need the :class:`pystac.Item` instances, you can instead use
 :meth:`ItemSearch.get_items_as_dicts <pystac_client.ItemSearch.get_items_as_dicts>`
 to retrive dictionary representation of the items, without incurring the cost of
-creating the pydantic Item objects.
+creating the Item objects.
 
 .. code-block:: python
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -159,26 +159,23 @@ requests to a service's "search" endpoint. This method returns a
 Instances of :class:`~pystac_client.ItemSearch` have 2 methods for iterating
 over results:
 
-* :meth:`ItemSearch.get_item_collections <pystac_client.ItemSearch.item_collections>`:
-  iterator over *pages* of results,
+* :meth:`ItemSearch.get_item_collections
+  <pystac_client.ItemSearch.get_item_collections>`: iterator over *pages* of results,
   yielding an :class:`~pystac.ItemCollection` for each page of results.
 * :meth:`ItemSearch.get_items <pystac_client.ItemSearch.get_items>`: an iterator over
-  individual Item objects, yielding a :class:`pystac.Item` instance for Item
-  that matches the search criteria.
+  individual Item objects, yielding a :class:`pystac.Item` instance for all Items
+  that match the search criteria.
+* :meth:`ItemSearch.get_items_as_dicts <pystac_client.ItemSearch.get_items_as_dicts>`:
+  iterate over individual results, yielding a :class:`dict` instance representing each
+  item that matches the search criteria. This eliminates the overhead of creating
+  class:`pystac.Item` objects with pydantic
 
-In addition three additional convenience methods are provided:
+Additionally, the ``matched`` method can be used to access result metadata about
+how many total items matched the query:
 
 * :meth:`ItemSearch.matched <pystac_client.ItemSearch.matched>`: returns the number
   of hits (items) for this search if the API supports the STAC API Context Extension.
   Not all APIs support returning a total count, in which case a warning will be issued.
-* :meth:`ItemSearch.get_all_items <pystac_client.ItemSearch.get_all_items>`: Rather
-  than return an iterator, this function will
-  fetch all items and return them as a single :class:`~pystac.ItemCollection`.
-* :meth:`ItemSearch.get_all_items_as_dict
-  <pystac_client.ItemSearch.get_all_items_as_dict>` : Like `get_all_items` this fetches
-  all items but returns them as a GeoJSON FeatureCollection dictionary rather than a
-  PySTAC object. This can be more efficient if only a dictionary of the results is
-  needed.
 
 .. code-block:: python
 
@@ -200,6 +197,35 @@ described in the
 `STAC API - Item Search: Paging <https://github.com/radiantearth/stac-api-spec/tree/master/item-search#paging>`__
 section. See the :mod:`Paging <pystac_client.paging>` docs for details on how to
 customize this behavior.
+
+Alternatively, the Items can be returned within ItemCollections, where each
+ItemCollection is one page of results retrieved from search:
+
+.. code-block:: python
+
+    >>> for ic in results.get_item_collections():
+    ...     for item in ic.items:
+    ...         print(item.id)
+    S2B_OPER_MSI_L2A_TL_SGS__20190101T200120_A009518_T18TXP_N02.11
+    MCD43A4.A2019010.h12v04.006.2019022234410
+    MCD43A4.A2019009.h12v04.006.2019022222645
+    MYD11A1.A2019002.h12v04.006.2019003174703
+    MYD11A1.A2019001.h12v04.006.2019002165238
+
+If you do not need the :class:`pystac.Item` instances, you can instead use
+:meth:`ItemSearch.get_items_as_dicts <pystac_client.ItemSearch.get_items_as_dicts>`
+to retrive dictionary representation of the items, without incurring the cost of
+creating the pydantic Item objects.
+
+.. code-block:: python
+
+    >>> for item_dict in results.get_items_as_dicts():
+    ...     print(item_dict["id"])
+    S2B_OPER_MSI_L2A_TL_SGS__20190101T200120_A009518_T18TXP_N02.11
+    MCD43A4.A2019010.h12v04.006.2019022234410
+    MCD43A4.A2019009.h12v04.006.2019022222645
+    MYD11A1.A2019002.h12v04.006.2019003174703
+    MYD11A1.A2019001.h12v04.006.2019002165238
 
 Query Extension
 ---------------

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -142,7 +142,7 @@ class Client(pystac.Catalog):
         """
         if self._stac_io.conforms_to(ConformanceClasses.ITEM_SEARCH):
             search = self.search()
-            yield from search.get_items()
+            yield from search.items()
         else:
             return super().get_items()
 

--- a/pystac_client/collection_client.py
+++ b/pystac_client/collection_client.py
@@ -30,7 +30,7 @@ class CollectionClient(pystac.Collection):
         root = self.get_root()
         if link is not None and root is not None:
             search = ItemSearch(link.href, method="GET", stac_io=root._stac_io)
-            yield from search.get_items()
+            yield from search.items()
         else:
             yield from super().get_items()
 

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -110,7 +110,7 @@ class ItemSearch:
 
     No request is sent to the API until a function is called to fetch or iterate
      through the resulting STAC Items,
-     either the :meth:`ItemSearch.get_item_collections` or :meth:`ItemSearch.get_items`
+     either the :meth:`ItemSearch.item_collections` or :meth:`ItemSearch.items`
      method is called and iterated over.
 
     All "Parameters", with the exception of ``max_items``, ``method``, and
@@ -193,7 +193,7 @@ class ItemSearch:
         sortby: A single field or list of fields to sort the response by
         fields: A list of fields to include in the response. Note this may
             result in invalid STAC objects, as they may not have required fields.
-            Use `get_items_as_dicts` to avoid object unmarshalling errors.
+            Use `items_as_dicts` to avoid object unmarshalling errors.
         max_items: The maximum number of items to get, even if there are more
             matched items.
         method: The http method, 'GET' or 'POST'
@@ -564,6 +564,19 @@ class ItemSearch:
         return found
 
     def get_item_collections(self) -> Iterator[ItemCollection]:
+        """DEPRECATED. Use :meth:`ItemSearch.item_collections` instead.
+
+        Yields:
+            ItemCollection : a group of Items matching the search criteria within an
+            ItemCollection
+        """
+        warnings.warn(
+            "get_item_collections() is deprecated, use item_collections() instead",
+            DeprecationWarning,
+        )
+        return self.item_collections()
+
+    def item_collections(self) -> Iterator[ItemCollection]:
         """Iterator that yields ItemCollection objects.  Each ItemCollection is
         a page of results from the search.
 
@@ -577,9 +590,21 @@ class ItemSearch:
             yield ItemCollection.from_dict(page, preserve_dict=False, root=self.client)
 
     def get_items(self) -> Iterator[Item]:
+        """DEPRECATED. Use :meth:`ItemSearch.items` instead.
+
+        Yields:
+            Item : each Item matching the search criteria
+        """
+        warnings.warn(
+            "get_items() is deprecated, use items() instead",
+            DeprecationWarning,
+        )
+        return self.items()
+
+    def items(self) -> Iterator[Item]:
         """Iterator that yields :class:`pystac.Item` instances for each item matching
         the given search parameters. Calls
-        :meth:`ItemSearch.get_item_collections` internally and yields from
+        :meth:`ItemSearch.item_collections` internally and yields from
         :attr:`ItemCollection.features <pystac_client.ItemCollection.features>` for
         each page of results.
 
@@ -587,17 +612,17 @@ class ItemSearch:
             Item : each Item matching the search criteria
         """
         nitems = 0
-        for item_collection in self.get_item_collections():
+        for item_collection in self.item_collections():
             for item in item_collection:
                 yield item
                 nitems += 1
                 if self._max_items and nitems >= self._max_items:
                     return
 
-    def get_items_as_dicts(self) -> Iterator[Dict[str, Any]]:
+    def items_as_dicts(self) -> Iterator[Dict[str, Any]]:
         """Iterator that yields :class:`dict` instances for each item matching
         the given search parameters. Calls
-        :meth:`ItemSearch.get_item_collections` internally and yields from
+        :meth:`ItemSearch.item_collections` internally and yields from
         :attr:`ItemCollection.features <pystac_client.ItemCollection.features>` for
         each page of results.
 

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -110,7 +110,7 @@ class ItemSearch:
 
     No request is sent to the API until a function is called to fetch or iterate
      through the resulting STAC Items,
-     either the :meth:`ItemSearch.item_collections` or :meth:`ItemSearch.items`
+     either the :meth:`ItemSearch.get_item_collections` or :meth:`ItemSearch.get_items`
      method is called and iterated over.
 
     All "Parameters", with the exception of ``max_items``, ``method``, and
@@ -579,7 +579,7 @@ class ItemSearch:
     def get_items(self) -> Iterator[Item]:
         """Iterator that yields :class:`pystac.Item` instances for each item matching
         the given search parameters. Calls
-        :meth:`ItemSearch.get_item_collections()` internally and yields from
+        :meth:`ItemSearch.get_item_collections` internally and yields from
         :attr:`ItemCollection.features <pystac_client.ItemCollection.features>` for
         each page of results.
 
@@ -597,7 +597,7 @@ class ItemSearch:
     def get_items_as_dicts(self) -> Iterator[Dict[str, Any]]:
         """Iterator that yields :class:`dict` instances for each item matching
         the given search parameters. Calls
-        :meth:`ItemSearch.get_item_collections()` internally and yields from
+        :meth:`ItemSearch.get_item_collections` internally and yields from
         :attr:`ItemCollection.features <pystac_client.ItemCollection.features>` for
         each page of results.
 
@@ -616,16 +616,17 @@ class ItemSearch:
 
     @lru_cache(1)
     def get_all_items_as_dict(self) -> Dict[str, Any]:
-        """DEPRECATED. Use get_items or get_itemcollections instead.
+        """DEPRECATED. Use :meth:`get_items` or :meth:`get_item_collections` instead.
             Convenience method that gets all items from all pages, up to
-            self._max_items, and returns an array of dictionaries.
+            the number provided by the max_items parameter, and returns an array of
+            dictionaries.
 
         Return:
             Dict : A GeoJSON FeatureCollection
         """
         warnings.warn(
             "get_all_items_as_dict is deprecated, use get_items or"
-            " get_itemcollections instead",
+            " get_item_collections instead",
             DeprecationWarning,
         )
         features = []
@@ -640,7 +641,7 @@ class ItemSearch:
 
     @lru_cache(1)
     def get_all_items(self) -> ItemCollection:
-        """DEPRECATED. Use get_items or get_itemcollections instead.
+        """DEPRECATED. Use :meth:`get_items` or :meth:`get_item_collections` instead.
             Convenience method that builds an :class:`ItemCollection` from all items
             matching the given search parameters.
 
@@ -648,7 +649,8 @@ class ItemSearch:
             item_collection : ItemCollection
         """
         warnings.warn(
-            "get_all_items is deprecated, use get_items or get_itemcollections instead",
+            "get_all_items is deprecated, use get_items or "
+            "get_item_collections instead",
             DeprecationWarning,
         )
         feature_collection = self.get_all_items_as_dict()

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -69,7 +69,9 @@ OP_MAP = {">=": "gte", "<=": "lte", "=": "eq", ">": "gt", "<": "lt"}
 
 
 # from https://gist.github.com/angstwad/bf22d1822c38a92ec0a9#gistcomment-2622319
-def dict_merge(dct: Dict, merge_dct: Dict, add_keys: bool = True) -> Dict:
+def dict_merge(
+    dct: Dict[Any, Any], merge_dct: Dict[Any, Any], add_keys: bool = True
+) -> Dict[Any, Any]:
     """Recursive dict merge.
 
     Inspired by :meth:``dict.update()``, instead of
@@ -191,7 +193,7 @@ class ItemSearch:
         sortby: A single field or list of fields to sort the response by
         fields: A list of fields to include in the response. Note this may
             result in invalid STAC objects, as they may not have required fields.
-            Use `get_all_items_as_dict` to avoid object unmarshalling errors.
+            Use `get_items_as_dicts` to avoid object unmarshalling errors.
         max_items: The maximum number of items to get, even if there are more
             matched items.
         method: The http method, 'GET' or 'POST'
@@ -540,7 +542,7 @@ class ItemSearch:
         )
 
     @lru_cache(1)
-    def matched(self) -> int:
+    def matched(self) -> Optional[int]:
         """Return number matched for search
 
         Returns the value from the `numberMatched` or `context.matched` field.
@@ -566,7 +568,8 @@ class ItemSearch:
         a page of results from the search.
 
         Yields:
-            Iterable[Item] : pystac_client.ItemCollection
+            ItemCollection : a group of Items matching the search criteria within an
+            ItemCollection
         """
         for page in self._stac_io.get_pages(
             self.url, self.method, self.get_parameters()
@@ -576,12 +579,12 @@ class ItemSearch:
     def get_items(self) -> Iterator[Item]:
         """Iterator that yields :class:`pystac.Item` instances for each item matching
         the given search parameters. Calls
-        :meth:`ItemSearch.item_collections()` internally and yields from
+        :meth:`ItemSearch.get_item_collections()` internally and yields from
         :attr:`ItemCollection.features <pystac_client.ItemCollection.features>` for
         each page of results.
 
-        Return:
-            Iterable[Item] : Iterate through resulting Items
+        Yields:
+            Item : each Item matching the search criteria
         """
         nitems = 0
         for item_collection in self.get_item_collections():
@@ -591,14 +594,40 @@ class ItemSearch:
                 if self._max_items and nitems >= self._max_items:
                     return
 
+    def get_items_as_dicts(self) -> Iterator[Dict[str, Any]]:
+        """Iterator that yields :class:`dict` instances for each item matching
+        the given search parameters. Calls
+        :meth:`ItemSearch.get_item_collections()` internally and yields from
+        :attr:`ItemCollection.features <pystac_client.ItemCollection.features>` for
+        each page of results.
+
+        Yields:
+            Item : each Item matching the search criteria
+        """
+        nitems = 0
+        for page in self._stac_io.get_pages(
+            self.url, self.method, self.get_parameters()
+        ):
+            for item in page.get("features", []):
+                yield item
+                nitems += 1
+                if self._max_items and nitems >= self._max_items:
+                    return
+
     @lru_cache(1)
-    def get_all_items_as_dict(self) -> Dict:
-        """Convenience method that gets all items from all pages, up to self._max_items,
-         and returns an array of dictionaries
+    def get_all_items_as_dict(self) -> Dict[str, Any]:
+        """DEPRECATED. Use get_items or get_itemcollections instead.
+            Convenience method that gets all items from all pages, up to
+            self._max_items, and returns an array of dictionaries.
 
         Return:
             Dict : A GeoJSON FeatureCollection
         """
+        warnings.warn(
+            "get_all_items_as_dict is deprecated, use get_items or"
+            " get_itemcollections instead",
+            DeprecationWarning,
+        )
         features = []
         for page in self._stac_io.get_pages(
             self.url, self.method, self.get_parameters()
@@ -611,12 +640,17 @@ class ItemSearch:
 
     @lru_cache(1)
     def get_all_items(self) -> ItemCollection:
-        """Convenience method that builds an :class:`ItemCollection` from all items
+        """DEPRECATED. Use get_items or get_itemcollections instead.
+            Convenience method that builds an :class:`ItemCollection` from all items
             matching the given search parameters.
 
         Return:
             item_collection : ItemCollection
         """
+        warnings.warn(
+            "get_all_items is deprecated, use get_items or get_itemcollections instead",
+            DeprecationWarning,
+        )
         feature_collection = self.get_all_items_as_dict()
         return ItemCollection.from_dict(
             feature_collection, preserve_dict=False, root=self.client

--- a/tests/cassettes/test_item_search/TestItemSearch.test_get_items_as_dicts.yaml
+++ b/tests/cassettes/test_item_search/TestItemSearch.test_get_items_as_dicts.yaml
@@ -1,0 +1,160 @@
+interactions:
+- request:
+    body: '{"limit": 10, "bbox": [-73.21, 43.99, -73.12, 44.05], "collections": ["naip"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '78'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: https://planetarycomputer.microsoft.com/api/stac/v1/search
+  response:
+    body:
+      string: !!binary |
+        H4sIAPR0l2IC/+2cW4/iNhSA/wpC6r6USXxJHIdqVKlTddVK7VbbfeoIoQAGsg1JlGRurfa/99hJ
+        wIEMDAsst6BhBI5jn1vMF+fY/7Wzl1i0u+1fhJc9JOIuCgIxzPwobHfa47wsbXfv/2v7I6j1mPVn
+        fctCDmVWP33qY95HDPUJwhwj7MoPLiLEhpMHg+gZTrxxqIEp4h2LGq7LsEs6sgjZjBG3Y1kGYowi
+        p9dZEgRaCPzwn7zvRARwZKjLVtT24jjwh54sND+n6sg0EWM4Ms2yOO2aZhx4oci85GUYzeKHTCTG
+        zB8mURqNMwOKTC/2zTTzhuYjNhc9pGbo+XH7S6fsPPYSEWZH6DiJooN1q3WTimBc381ERN/vX0PT
+        z8QsNd8cUJonEvHoi6evE2fkZZ4UR/Zuzrz4x4Vct1Ksd/LA7RZhnvlZIC32uxe3onFLnr4wYyae
+        M3OazYL2FwhwL01FBgEN19LMmwj5YUkDKYF4eBJpZgyCaABSJ8J48sNR9JQaoFtuuUeECBjOlOJI
+        A4Jow5kSzlQym+tkNzJf87MSxISi8Q8tzee34PO8ME6isR+I22EQPYxuojjzZ/6/YgQtJFGgRoa2
+        NGm7t7DEx/c//fqxdffhfSuDM6GmiLoDLxzll3LozVQl1QZ4ZRaF/aIsgTLp5uLr+0SIcKXSRJVq
+        1X4KHsRKrYEs1Cr98evHlTqhn0DZSKTDxI/VqAJlwktu/HCceEqY3pdOewYhpVTcl7vGk9Hw7d56
+        zpbCCaLcD3X7zwXUfPDL+5/vWr+LTJWDEtn0YTYAaYIjBR1ByPgcT5YD73MsJroqCzE1XT7NC6Ui
+        EFJqMAI95hWg7Le/PvzRevKzaWskxt5DkLVguB6JxA8nexgoyl4N+W+3IeNdPgrcKgPkX/oDf/Sc
+        F3zn3OHvyB2BN1076C9M5ssPMlBzhcWoXw6Qmok+Fsdai8Fz34Np0ZIRh5NvaKG5HaJHkShNeksx
+        BvK0v4B5YEiDKyV5UWbJK/wZBS+TKB9jomTkh16mGru/zxGFcw1bep37ZXCxMbKLYkw4o0TnmSXy
+        cajWRLXhnvSeBjcwDEkE6IBzolgkmS/Uj8YkBQJDBuvIEVfAQCxVkNa7wegGu58Q6qq/v+FM2UD3
+        BQazokre2OduAWXMcjlzDdSxuEMJx9Aos21GOXywOEeuhQzUK84RcTppdwlzMS8aht/0TCgaLNtN
+        p5606D0mDrM6oBYrz84SL0zHUTKDo1J4aLgz715+uUF6p53yjUEAMIvEhz4MeyJMJTpIT5cRKg/d
+        LA4ZE7j6HwaGH5kigqg0oBUzHU7FzDNKfNl4phQ590JdC71CHgi1NHeUqqN+aDQ8BveD2/vhFnjs
+        cKYCglIw8xyQqa0CClGOWAPI1wzIbwipIwDymwL9xACZFqzyquwNIJ8QIL/BW+cAyJvVuBZA3jxk
+        XDsg79lChwZksuAWjZBLciEMWRohE6oDzQr8WNzVEVlv+giMbIP4jkHd8gWQCopRN4dljrDh6McA
+        8F2+GzUTay01rwik4XPR+8Xgs7N0ASCX0FfwmcCdi20XsSINqcKKY8cpo82htMHnq8fn9SF1LHze
+        FOinjM91sjf4fKr4XO+ts8PnWjWuCp/XDhkNPu/VQgfEZ8wpl4hScksJxBq5EIbLSWNiU0a5DjQr
+        8GNxTueNLLW9Mz8j94bQ7eaYEUK2mmNmDMMtrtVhlu0wuNdVvOo4Xz/HbGOgZZU0sGaOuei+Asmq
+        00uAZPUYhS49RkEuttZBcvnQgTA2h2Tg5fyhBaFWA8lXn4SxPqSOlYSxKdBPOQmjTvYGkk81CaPe
+        W2eXhFGrxlUlYawdMpokjL1a6MCQzDRu0SC5JBcbY6pDsqMDzQr8OJRbGiRX2t4HJGNrK0imLrd5
+        kYiBGM4hmWFmcJUT4WCyEyTbLl8LyWX3lUQM1eklQbJ4IyRjlxJKy4AgTg7J2JVJy0VMOaSB5AaS
+        14bUESFZnDEkiwaSzwiSxWVAsrh6SBYNJH8bCx0SkgmW1FtiS4m3GrgAI5elLuAy13FmBX0Akeec
+        vdTyEQjZsjijxZwxZmoa2UaM5NDMESdwzX4tIXM5jbyekMvuK4SsOr2kXItqjPNXcy1kmBBcPlcg
+        rCRkqF0+mnBwQ8hNrsXakDpirsXaQD/xXIsV2RtCPuFcixpvnWOuxaoa15Zr8fqQ0eRa7NVChyZk
+        a8EtC0SekwthyNUZWeeZFfYBCLR1RNab3p2R+dapFjbCTDEyk5ieM7LD7eUMZc7JbrC8aV1fIUcl
+        50J1enHr+qYyxuHmATWL+RpC3mExnxZHx17BVwnp47Iwq2AJe2UF1ULghoSPSMJMJ+G3+OoEOXjr
+        gLvKBXsL/Rv03d0s17k0D+kvYi3jL5P4i+x1+MvqV+pZqwv0+IHX5S3roi3Ts+YQXKnjkstcrCfW
+        MnEza9ww8RazxifAxLUhfcpMvCpww8SnysR1vjo7Jq5R4ipnhhsm3qdZrnMOuMKRLtsHE786JcwP
+        PBO8rEvdxLDtai9uW5c1T1zZ4nB+HVjNnsgNEX/tnshaFB17I+RKQJ8YEdduRLsQuCHiEyLijb46
+        ByLepMRV7nu80L9JId7dLNe3w3GFDl3HrsdhazscPtKGxyu61O5/vDpFfEHbIVcWm76Gw83+FA0Q
+        b7M/xQkAMT03IKYNEJ8NENNLAGJ65UBMGyA+gFmudLeJyryq5e4Dio+2+cSyLnV7UVTI2UH83Lem
+        6K2yaiies404BRE8jSRN//nhr0+74VUKoTCcSvCORuqiCOAHPGt3MaqyeP6Aw80ZPL/lg7tALVaV
+        jVW0yksv+keEhTbdDah2QsS6ezeFOQEM/gcWYCvyRnEAAA==
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2143'
+      Content-Type:
+      - application/geo+json
+      Date:
+      - Wed, 01 Jun 2022 14:17:23 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Azure-Ref:
+      - 09HSXYgAAAAAN/WrHkOHSTrMaVgXSKRyuTU5aMjIxMDYwNjE0MDUxADkyN2FiZmE2LTE5ZjYtNGFmMS1hMDlkLWM5NTlkOWExZTY0NA==
+      X-Cache:
+      - CONFIG_NOCACHE
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"limit": 10, "bbox": [-73.21, 43.99, -73.12, 44.05], "collections": ["naip"],
+      "token": "next:vt_m_4407363_sw_18_h_20160804"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '125'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: https://planetarycomputer.microsoft.com/api/stac/v1/search
+  response:
+    body:
+      string: !!binary |
+        H4sIAPR0l2IC/+2dbW+rxhKA/4plqf1SB/YFlsVVVKm56lGv1J7q9HzqkWVhe21zigEBebvV+e93
+        dgGzxg52Ert+I0oie1l2Z2aH9cNkhvzTzZ5j0e13fxFedp+IuygIxDjzo7Db607ztrTb//JP159A
+        r4dsuBhaFnIoo8NUDDEfzocEYYY4suCM0Sh6gt43DjWwSwmlPYsarssIcXqqEbvYJT3LMhBjxCGD
+        Xm1+GCPww7/zKRMRwJGxLlLR24vjwB97stH8mqoj80RM4cg8y+K0b5px4IUi85LncbSI7zORGAt/
+        nERpNM0MaDK92DfTzBubD9isZkjN0PPj7rdeOXnsJSLMjjBxEkUHm1abJhXBdPM0MxH9sH8NTT8T
+        i9Rs9iPN/Il48MXj22SYeJknZZBTmgsv/qkS5lbK8r08cLvNpTM/C6RtfvPiTjTtyHMqg2XiKTPn
+        2SLofgNX9tJUZOC6cLEsvJmQL2piy2nF/aNIM2MURCMQNRHGox9OosfUAIVyGz0gRMBEppRCmgox
+        NF4omUwlqPmywEbma+upxDChafpjR1vbW1jbvDFOoqkfiNtxEN1PbqI48xf+/8QERkiiQF34XWnF
+        7qCyw6cPP//6qXP38UMngzOhp4j6Iy+c5Jds6C1UJzUGLMQiCodFWwJtcmWLtx8SIcK1TjPVqnX7
+        ObgXa71GslHr9Puvn9b6hH4CbRORjhM/VrsHtAkvufHDaeIpYQbfet0FeJFScV+LNZ1Nxruu1VNW
+        cyVwaz/Urb8UT1uBXz78567zm8hUO6iQze8XI5AlOIrDEYSMr/Gs7nRfYzHTFamE1DT5vGyUaoA7
+        qQ0HtFh2gLb//vnx986jn807EzH17oOsA1vyRCR+ONvDvlDOashfb9ghvs8v+luldf5mOPInT3nD
+        d84d/o7cEfihjbt5ZSdfvpCemWspJsNyE9Ts8qk41qk2yH1vmMVIRhzODm2WpfLRg0iU+IOaN4EQ
+        3W9gE9i44IpInpUt8g5/RMHzLMp3kiiZ+KGXqcG+5BRCMHUqCBn0vtQxxMa4bHUxplyHkzWQcShn
+        ZXNt5IFcM41VYLeRn+g9WJIoFknmC/XJMEuBo5DBkP5luT25zwrYfqVK0og3iN8g6zNCffX9Fwwk
+        x+s/wxZWdMnH/tovoItZFmfUALW4QzFzDavHbMQINxA0ccQJXKyD4hwRp7NunzAX82Jg+MTOhEK8
+        ctx07kkLf8HEsXnPhXUtz84SL0ynUbKAoxt0QTDjUhr55gYZtqt9cduqRFI95A82kLShRIchbIYi
+        TCU2SL8onVgeuqkOGTPYFe5Hhh+ZIgLHNWAUMx3PxcIzSnTZeqZUKF+yTSMMCnnAMdN8VVUf9eGj
+        ETGFqwA5w/BRuwoc4qwSMbFtZtvKZSh1mJUTMceOQ5XTIepQ2hLxNRPxS350BCJ+2aVPjIhpASgv
+        CNwS8QkR8da1Ogci3qbEtRDxC/pfOxHvwyyHJGJOuUMrCilxVuMQwnAJv8QGuuc6nqyhDIAcXQ5S
+        G/t1ULzCiK5NNkCxc0Oc10ExIKmtCJgxwH4JxZbtAB3nnOw4QHNvhWIsodjZDMVruuRQXEizCYod
+        xCuRLgGK1a2hNUzVhYDlhWAB8TP1AiPEavFiKvVXt1OY59FiZMN9mFXckFFl6ZaNrzta3OROxwob
+        N7v4cWnZksYDSXJ4sWrhvHXJW1o+Ii1bOi3vslYnSMuvdririh83bBVtIHmP9jkgPyObc8euSKVA
+        X51VbIzsZZSYM0p0hKnBjkO1IWojv4aegcDquGzJGDJhTbhsreGyy4GNkQJRwuWgwPmMukUM2bXe
+        iMsOs92eDWi7iZZxwbrL2RUeY33OiwkS8+LGcBcedlxc3EsxzpZETMtoMUesJeKrjxY3OdSxwsbN
+        Tn5iRLwSzluXvCXiEyLirWt1DkS8TYmrih83bBVtIHmP9jkwEfMKVDQgpsuAMrI0ICZcJ5g12gHo
+        szUk1oc+AhHbIL5TBJCpAmEgYo5IAcmuy99HxHYjEZeza0RczHkxEWJau+dD7gtErP7oUMaICSPL
+        /AmGy6QdarVE3GYUNzjUEVOLG5z8lGPE65K3RHyqMeJNa3V2MeINSlxbjvFLW0UbI96jfQ6cY8FY
+        RSpajkXJKjbGVM+xcHSEWcMdh3Ks5VisjL0PJkbuq5iYutzmBYwipqLEls2wU0RsHUzezMQYmNh2
+        G5m4nH0lSqzmvCQmFjsxsUpOt5dp6NamKrsWiVskbvCnY1fbnSUSixaJzwaJxSUgsbhyJBYtEh/e
+        Pv9aIZ61sRBPFpgtK/EsrAHMGusAENONhXjWMXg4r3VDy8o7tF5591YetoGHWXOMuJx9hYfVnBdX
+        WrdbjLiqscNVjR1ra+xaIN7JoY5dbHcWQLyxCKoF4tPPmti0VmeXNbFBiausumuB+LD2OXQdHqtI
+        Ra/DY2+rw3NcvQ5PH/sYTFwrvENl4R16X+FdESOWhYtNTKwX2mF9zkti4t1jxGRZlUlIFSNeOhRz
+        WyZumbjBoY7IxOJsmbgNEp8PE4tLYGJx5UzcBon/BfscOkiMK1LRo8R8mUrs6M9rozrCrOGOxau8
+        ifrYx2BiG2FWMDFReb3MRg5nBZ9yTt4VJ95WXVfMvsLEas7LfNoEkUkh+Qu3/iy29mkTLRG/8mkT
+        NXc6iadNrLn4cYmYrAAKaSr+V5K3RHxEIiY6Ee+yVidIxK92uOt92sTqVtGmTezRPu3TJqTZ5MPZ
+        MGniYdI+beKYecSNPNzmEbdA/Mo84hMB4mYfP2UgXpe8BeJTBeJNa3V2QLxBievNI26B+GD2afOI
+        38jDbR7xHnl4sI6noXjKthIUOOQ8kiD9x8c/P7+PqFJY6/FconY0UT4ewCd0Bv6CVrOW879LuDl1
+        534s10oDMmlj5X/ySor+FmGhTX9XOqvhWXSfXo4hpEb9Lf9T7oRo/f3TFOYEBPo/eJV6O8FxAAA=
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '2222'
+      Content-Type:
+      - application/geo+json
+      Date:
+      - Wed, 01 Jun 2022 14:17:24 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Azure-Ref:
+      - 09HSXYgAAAADdIeMyUv+4R56ucppR1iHFTU5aMjIxMDYwNjE0MDUxADkyN2FiZmE2LTE5ZjYtNGFmMS1hMDlkLWM5NTlkOWExZTY0NA==
+      X-Cache:
+      - CONFIG_NOCACHE
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_item_search/TestItemSearch.test_items_as_dicts.yaml
+++ b/tests/cassettes/test_item_search/TestItemSearch.test_items_as_dicts.yaml
@@ -19,7 +19,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAPR0l2IC/+2cW4/iNhSA/wpC6r6USXxJHIdqVKlTddVK7VbbfeoIoQAGsg1JlGRurfa/99hJ
+        H4sIAGe+l2IC/+2cW4/iNhSA/wpC6r6USXxJHIdqVKlTddVK7VbbfeoIoQAGsg1JlGRurfa/99hJ
         wIEMDAsst6BhBI5jn1vMF+fY/7Wzl1i0u+1fhJc9JOIuCgIxzPwobHfa47wsbXfv/2v7I6j1mPVn
         fctCDmVWP33qY95HDPUJwhwj7MoPLiLEhpMHg+gZTrxxqIEp4h2LGq7LsEs6sgjZjBG3Y1kGYowi
         p9dZEgRaCPzwn7zvRARwZKjLVtT24jjwh54sND+n6sg0EWM4Ms2yOO2aZhx4oci85GUYzeKHTCTG
@@ -65,13 +65,13 @@ interactions:
       Content-Type:
       - application/geo+json
       Date:
-      - Wed, 01 Jun 2022 14:17:23 GMT
+      - Wed, 01 Jun 2022 19:30:46 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       X-Azure-Ref:
-      - 09HSXYgAAAAAN/WrHkOHSTrMaVgXSKRyuTU5aMjIxMDYwNjE0MDUxADkyN2FiZmE2LTE5ZjYtNGFmMS1hMDlkLWM5NTlkOWExZTY0NA==
+      - 0Zr6XYgAAAABsVlagafu2RqCzig51hgH7TU5aMjIxMDYwNjE0MDI3ADkyN2FiZmE2LTE5ZjYtNGFmMS1hMDlkLWM5NTlkOWExZTY0NA==
       X-Cache:
       - CONFIG_NOCACHE
     status:
@@ -98,7 +98,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAPR0l2IC/+2dbW+rxhKA/4plqf1SB/YFlsVVVKm56lGv1J7q9HzqkWVhe21zigEBebvV+e93
+        H4sIAGe+l2IC/+2dbW+rxhKA/4plqf1SB/YFlsVVVKm56lGv1J7q9HzqkWVhe21zigEBebvV+e93
         dgGzxg52Ert+I0oie1l2Z2aH9cNkhvzTzZ5j0e13fxFedp+IuygIxDjzo7Db607ztrTb//JP159A
         r4dsuBhaFnIoo8NUDDEfzocEYYY4suCM0Sh6gt43DjWwSwmlPYsarssIcXqqEbvYJT3LMhBjxCGD
         Xm1+GCPww7/zKRMRwJGxLlLR24vjwB97stH8mqoj80RM4cg8y+K0b5px4IUi85LncbSI7zORGAt/
@@ -145,13 +145,13 @@ interactions:
       Content-Type:
       - application/geo+json
       Date:
-      - Wed, 01 Jun 2022 14:17:24 GMT
+      - Wed, 01 Jun 2022 19:30:47 GMT
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Vary:
       - Accept-Encoding
       X-Azure-Ref:
-      - 09HSXYgAAAADdIeMyUv+4R56ucppR1iHFTU5aMjIxMDYwNjE0MDUxADkyN2FiZmE2LTE5ZjYtNGFmMS1hMDlkLWM5NTlkOWExZTY0NA==
+      - 0Z76XYgAAAACu5+MprhBqQrVcK11NG1t4TU5aMjIxMDYwNjE0MDI3ADkyN2FiZmE2LTE5ZjYtNGFmMS1hMDlkLWM5NTlkOWExZTY0NA==
       X-Cache:
       - CONFIG_NOCACHE
     status:

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -507,7 +507,7 @@ class TestItemSearch:
             max_items=20,
             limit=10,
         )
-        results = search.get_items()
+        results = search.items()
 
         assert all(isinstance(item, pystac.Item) for item in results)
 
@@ -521,7 +521,7 @@ class TestItemSearch:
             url=SEARCH_URL,
             ids=ids,
         )
-        results = list(search.get_items())
+        results = list(search.items())
 
         assert len(results) == 1
         assert all(item.id in ids for item in results)
@@ -531,13 +531,13 @@ class TestItemSearch:
         # Datetime range string
         datetime_ = "2019-01-01T00:00:01Z/2019-01-01T00:00:10Z"
         search = ItemSearch(url=SEARCH_URL, datetime=datetime_)
-        results = list(search.get_items())
+        results = list(search.items())
         assert len(results) == 33
 
         min_datetime = datetime(2019, 1, 1, 0, 0, 1, tzinfo=tzutc())
         max_datetime = datetime(2019, 1, 1, 0, 0, 10, tzinfo=tzutc())
         search = ItemSearch(url=SEARCH_URL, datetime=(min_datetime, max_datetime))
-        results = search.get_items()
+        results = search.items()
         assert all(
             min_datetime <= item.datetime <= (max_datetime + timedelta(seconds=1))
             for item in results
@@ -561,7 +561,7 @@ class TestItemSearch:
         search = ItemSearch(
             url=SEARCH_URL, intersects=intersects_dict, collections="naip"
         )
-        results = list(search.get_items())
+        results = list(search.items())
         assert len(results) == 30
 
         # Geo-interface object
@@ -574,7 +574,7 @@ class TestItemSearch:
         search = ItemSearch(
             url=SEARCH_URL, intersects=intersects_obj, collections="naip"
         )
-        results = search.get_items()
+        results = search.items()
         assert all(isinstance(item, pystac.Item) for item in results)
 
     @pytest.mark.vcr
@@ -588,7 +588,7 @@ class TestItemSearch:
         )
 
         # Check that the current page changes on the ItemSearch instance when a new page is requested
-        pages = list(search.get_item_collections())
+        pages = list(search.item_collections())
 
         assert pages[1] != pages[2]
         assert pages[1].items != pages[2].items
@@ -606,7 +606,7 @@ class TestItemSearch:
         assert len(item_collection.items) == 20
 
     @pytest.mark.vcr
-    def test_get_items_as_dicts(self) -> None:
+    def test_items_as_dicts(self) -> None:
         search = ItemSearch(
             url=SEARCH_URL,
             bbox=(-73.21, 43.99, -73.12, 44.05),
@@ -614,7 +614,7 @@ class TestItemSearch:
             limit=10,
             max_items=20,
         )
-        assert len(list(search.get_items_as_dicts())) == 20
+        assert len(list(search.items_as_dicts())) == 20
 
 
 class TestItemSearchQuery:
@@ -626,7 +626,7 @@ class TestItemSearchQuery:
             query=["gsd=10"],
             max_items=1,
         )
-        items1 = list(search.get_items())
+        items1 = list(search.items())
 
         search = ItemSearch(
             url=SEARCH_URL,
@@ -634,7 +634,7 @@ class TestItemSearchQuery:
             query={"gsd": {"eq": 10}},
             max_items=1,
         )
-        items2 = list(search.get_items())
+        items2 = list(search.items())
 
         assert len(items1) == 1
         assert len(items2) == 1

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -605,6 +605,17 @@ class TestItemSearch:
         item_collection = search.get_all_items()
         assert len(item_collection.items) == 20
 
+    @pytest.mark.vcr
+    def test_get_items_as_dicts(self) -> None:
+        search = ItemSearch(
+            url=SEARCH_URL,
+            bbox=(-73.21, 43.99, -73.12, 44.05),
+            collections="naip",
+            limit=10,
+            max_items=20,
+        )
+        assert len(list(search.get_items_as_dicts())) == 20
+
 
 class TestItemSearchQuery:
     @pytest.mark.vcr


### PR DESCRIPTION
**Related Issue(s):** #187


**Description:**

- deprecate get_all_items_as_dict and get_all_items, as these can retrieve the entire catalog without the user really knowing
- add get_items_as_dicts to allow for retrieval of unmarshalled items 

**PR Checklist:**

- [X] Code is formatted
- [X] Tests pass
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)