### PR TITLE
Better error message when trying to open a Collection with Client.open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Search `filter-lang` defaults to `cql2-json` instead of `cql-json` [#169](https://github.com/stac-utils/pystac-client/pull/169)
 - Search `filter-lang` will be set to `cql2-json` if the `filter` is a dict, or `cql2-text` if it is a string [#169](https://github.com/stac-utils/pystac-client/pull/169)
 - Search parameter `intersects` is now typed to only accept a str, dict, or object that implements `__geo_interface__` [#169](https://github.com/stac-utils/pystac-client/pull/169)
+- Better error message when trying to open a Collection with `Client.open` [#222](https://github.com/stac-utils/pystac-client/pull/222)
 
 
 ### Deprecated

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -6,6 +6,7 @@ import pystac.validation
 
 from pystac_client.collection_client import CollectionClient
 from pystac_client.conformance import ConformanceClasses
+from pystac_client.errors import ClientTypeError
 from pystac_client.exceptions import APIError
 from pystac_client.item_search import ItemSearch
 from pystac_client.stac_api_io import StacApiIO
@@ -92,6 +93,25 @@ class Client(pystac.Catalog):
         cat._stac_io._conformance = cat.extra_fields.get("conformsTo", [])
 
         return cat
+
+    @classmethod
+    def from_dict(
+        cls,
+        d: Dict[str, Any],
+        href: Optional[str] = None,
+        root: Optional[pystac.Catalog] = None,
+        migrate: bool = False,
+        preserve_dict: bool = True,
+    ) -> "Client":
+        try:
+            return super().from_dict(
+                d=d, href=href, root=root, migrate=migrate, preserve_dict=preserve_dict
+            )
+        except pystac.STACTypeError:
+            raise ClientTypeError(
+                f"Could not open Client (href={href}), "
+                f"expected type=Catalog, found type={d.get('type', None)}"
+            )
 
     @lru_cache()
     def get_collection(self, collection_id: str) -> CollectionClient:

--- a/pystac_client/errors.py
+++ b/pystac_client/errors.py
@@ -1,0 +1,4 @@
+class ClientTypeError(Exception):
+    """Raised when trying to open a Client on a non-catalog STAC Object."""
+
+    pass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,6 +11,7 @@ from pystac import MediaType
 
 from pystac_client import Client
 from pystac_client.conformance import ConformanceClasses
+from pystac_client.errors import ClientTypeError
 
 from .helpers import STAC_URLS, TEST_DATA, read_data_file
 
@@ -325,6 +326,11 @@ class TestAPI:
         history = requests_mock.request_history
         assert len(history) == 2
         assert history[1].url == pc_collection_href
+
+    def test_opening_a_collection(self) -> None:
+        path = str(TEST_DATA / "planetary-computer-aster-l1t-collection.json")
+        with pytest.raises(ClientTypeError):
+            Client.open(path)
 
 
 class TestAPISearch:


### PR DESCRIPTION
**Related Issue(s):**
- Closes #103 

**Description:** After digging a bit, I think it does _not_ make sense to allow `Client.open` to work for collections, since we have `ClientCollection` to handle that case. This PR improves the error message when trying to open a collection with `Client.open`.

Now:

```shell
$ stac-client search https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a
Could not open Client (href=https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a), expected type=Catalog, found type=Collection
```

Before:

```shell
$ stac-client search https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a
{'id': 'sentinel-2-l2a', 'type': 'Collection', <snip>...</snip> L2A (bottom-of-atmosphere).'} does not represent a Client instance
```


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)