### PR TITLE
docs: fix return type of ItemSearch.items_as_dicts

### DIFF
--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -657,7 +657,7 @@ class ItemSearch:
         each page of results.
 
         Yields:
-            Item : each Item matching the search criteria
+            Dict[str, Any] : each Item matching the search criteria as a JSON dictionary
         """
         nitems = 0
         for page in self._stac_io.get_pages(


### PR DESCRIPTION
**Related Issue(s):** None

**Description:** In the docstring, fix the return type for `items_as_dicts`.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass