### PR TITLE
revert max_items to default to None (retrieve all items)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - (Reverted change in 0.4.0) Item Search now returns an unlimited number of result Items from
   its "items" methods. The `max_items` parameter no longer defaults to 100, but instead to None.
   It is recommended to set `max_items` to avoid the possibility of exhausting memory if there are a
-  very large number of results with methods like `ItemSearch.item_collection()`
+  very large number of results with methods like `ItemSearch.item_collection()` [#278](https://github.com/stac-utils/pystac-client/pull/278)
 
 ## [v0.4.0] - 2022-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix type annotation of `Client._stac_io` and avoid implicit re-exports in `pystac_client.__init__.py` [#249](https://github.com/stac-utils/pystac-client/pull/249)
 - Added `ItemSearch.item_collection()` as a replacement for the deprecated `ItemSearch.get_all_items()` [#237](https://github.com/stac-utils/pystac-client/issues/237)
 
+## Changed
+
+- (Reverted change in 0.4.0) Item Search now returns an unlimited number of result Items from
+  its "items" methods. The `max_items` parameter no longer defaults to 100, but instead to None.
+  It is recommended to set `max_items` to avoid the possibility of exhausting memory if there are a
+  very large number of results with methods like `ItemSearch.item_collection()`
+
 ## [v0.4.0] - 2022-06-08
 
 ### Added

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -76,7 +76,7 @@ OP_MAP = {
 
 OPS = list(OP_MAP.keys())
 
-DEFAULT_LIMIT_AND_MAX_ITEMS = 100
+DEFAULT_LIMIT = 100
 
 
 # from https://gist.github.com/angstwad/bf22d1822c38a92ec0a9#gistcomment-2622319
@@ -144,8 +144,8 @@ class ItemSearch:
             total number of Items returned from the :meth:`items`,
             :meth:`item_collections`, and :meth:`items_as_dicts methods`. The client
             will continue to request pages of items until the number of max items is
-            reached. This parameter defaults to 100. Setting this to ``None`` will
-            allow iteration over a possibly very large number of results.
+            reached. This parameter defaults to None, which can result in iteration
+            over possibly a very large number of results.
         stac_io: An instance of StacIO for retrieving results. Normally comes
             from the Client that returns this ItemSearch client: An instance of a
             root Client used to set the root on resulting Items.
@@ -217,10 +217,10 @@ class ItemSearch:
         url: str,
         *,
         method: Optional[str] = "POST",
-        max_items: Optional[int] = DEFAULT_LIMIT_AND_MAX_ITEMS,
+        max_items: Optional[int] = None,
         stac_io: Optional[StacApiIO] = None,
         client: Optional["_client.Client"] = None,
-        limit: Optional[int] = DEFAULT_LIMIT_AND_MAX_ITEMS,
+        limit: Optional[int] = DEFAULT_LIMIT,
         ids: Optional[IDsLike] = None,
         collections: Optional[CollectionsLike] = None,
         bbox: Optional[BBoxLike] = None,


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/pystac-client/issues/237


**Description:**

Revert max_items to default to None instead of 100, so all items are retrived.

**PR Checklist:**

- [X] Code is formatted
- [X] Tests pass
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)