### PR TITLE
Removes duplicate text in usage documentation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -297,7 +297,7 @@ Automatically modifying results
 -------------------------------
 
 Some systems, like the `Microsoft Planetary Computer <http://planetarycomputer.microsoft.com/>`__,
-have public STAC metadata but require require some `authentication <https://planetarycomputer.microsoft.com/docs/concepts/sas/>`__
+have public STAC metadata but require some `authentication <https://planetarycomputer.microsoft.com/docs/concepts/sas/>`__
 to access the actual assets.
 
 ``pystac-client`` provides a ``modifier`` keyword that can automatically


### PR DESCRIPTION
**Related Issue(s):** 

- # None


**Description:**
I noticed "require" was duplicated as I was using the documentation

**PR Checklist:**

- [/] Code is formatted
- [/] Tests pass
- [N/A] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)