### PR TITLE
Fix StacApiIO's write_text_to_href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix variable name in quickstart example [#316](https://github.com/stac-utils/pystac-client/pull/316)
+- `StacApiIO.write_text_to_href` [#312](https://github.com/stac-utils/pystac-client/pull/312)
 
 ## Removed
 

--- a/pystac_client/stac_api_io.py
+++ b/pystac_client/stac_api_io.py
@@ -151,7 +151,7 @@ class StacApiIO(DefaultStacIO):
         if bool(urlparse(href).scheme):
             raise APIError("Transactions not supported")
         else:
-            return super().write_text_to_href(*args, **kwargs)
+            return super().write_text_to_href(href, *args, **kwargs)
 
     def stac_object_from_dict(
         self,

--- a/tests/test_stac_api_io.py
+++ b/tests/test_stac_api_io.py
@@ -113,3 +113,11 @@ class TestSTAC_IOOverride:
         assert request_qp_name in actual_qp
         assert len(actual_qp[request_qp_name]) == 1
         assert actual_qp[request_qp_name][0] == request_qp_value
+
+    def test_write(self, tmp_path: Path) -> None:
+        stac_api_io = StacApiIO()
+        test_file = tmp_path / "test.txt"
+        stac_api_io.write_text_to_href(str(test_file), "Hi there!")
+        with open(test_file) as file:
+            data = file.read()
+        assert data == "Hi there!"


### PR DESCRIPTION
**Description:**

The href was not being passed, which broke writing. This popped up when reading an item with pystac-client, modifying it, then writing it to the local filesystem with `save_object`.

I think this is worth a bugfix release (v0.5.1)?

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)