### PR TITLE
Fix variable name in quickstart example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix variable name in quickstart example.
+
 ## Removed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fix variable name in quickstart example.
+- Fix variable name in quickstart example [#316](https://github.com/stac-utils/pystac-client/pull/316)
 
 ## Removed
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -107,7 +107,7 @@ Create a search:
         max_items=10,
         collections=['sentinel-s2-l2a-cogs'],
         bbox=[-72.5,40.5,-72,41])
-    print(f"{mysearch.matched()} items found")
+    print(f"{my_search.matched()} items found")
 
 The ``items()`` iterator method can be used to iterate through all resulting items.
 


### PR DESCRIPTION
**Related Issue(s):** 

- None (minor example fix)


**Description:**

Name is missing a `_`

**PR Checklist:**

- [X] Code is formatted
- [ ] Tests pass (NA)
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)