### PR TITLE
Remove mention of STAC_URL in Client.open docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix variable name in quickstart example [#316](https://github.com/stac-utils/pystac-client/pull/316)
 - `StacApiIO.write_text_to_href` [#312](https://github.com/stac-utils/pystac-client/pull/312)
+- Removed mention of STAC_URL in `Client.open` docstring [#317](https://github.com/stac-utils/pystac-client/pull/317)
 
 ## Removed
 

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -98,8 +98,7 @@ class Client(pystac.Catalog):
         This function will read the root catalog of a STAC Catalog or API
 
         Args:
-            url : The URL of a STAC Catalog. If not specified, this will use the
-                `STAC_URL` environment variable.
+            url : The URL of a STAC Catalog.
             headers : A dictionary of additional headers to use in all requests
                 made to any part of this Catalog/API.
             parameters: Optional dictionary of query string parameters to


### PR DESCRIPTION
**Related Issue(s):** 

- #


**Description:**

Quick patch that updates the docstring of [`pystac_client.Client.open`](https://pystac-client.readthedocs.io/en/v0.5.0/api.html#pystac_client.Client.open) to remove mentioning the `STAC_URL` environment variable, since it doesn't work anymore.

Actually got a bit confused because the v0.2.0 changelog at https://github.com/stac-utils/pystac-client/blob/v0.5.0/CHANGELOG.md#v020---2021-08-04 says the fallback `STAC_URL` was added in #48 (5 May 2021), but the option was removed afterwards in #81 (2 Aug 2021) :sweat_smile:

Discovered this when writing unit tests at https://github.com/weiji14/zen3geo/pull/59 and was wondering why I kept getting `AttributeError: 'NoneType' object has no attribute 'lower'` when using `url=None` with the `STAC_URL` environment variable set. This was using pystac-client v0.4.0, but I think it's an issue from v0.2.0 to v0.5.0.

**PR Checklist:**

- [x] Code is formatted
- [ ] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)