### PR TITLE
Check dev and docs in the same environment

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,10 +18,10 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-#          - "3.11-dev"
+        #          - "3.11-dev"
         os:
           - ubuntu-latest
-#          - windows-latest
+    #          - windows-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -29,8 +29,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: 'setup.py'
+          cache: "pip"
+          cache-dependency-path: "setup.py"
 
       - name: Execute linters and test suites
         run: ./scripts/cibuild
@@ -40,7 +40,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          fail_ci_if_error: false 
+          fail_ci_if_error: false
 
   min-versions:
     name: min-versions
@@ -50,8 +50,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9
-          cache: 'pip'
-          cache-dependency-path: 'requirements-min.txt'
+          cache: "pip"
+          cache-dependency-path: "requirements-min.txt"
       - name: Install minimum requirements
         run: pip install -r requirements-min.txt
       - name: Install
@@ -69,8 +69,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9
-          cache: 'pip'
-          cache-dependency-path: 'requirements-docs.txt'
+          cache: "pip"
+          cache-dependency-path: "requirements-docs.txt"
       - name: Install pandoc
         run: sudo apt-get update && sudo apt-get -y install pandoc
       - name: Install docs requirements
@@ -88,8 +88,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9
-          cache: 'pip'
-          cache-dependency-path: 'setup.py'
+          cache: "pip"
+          cache-dependency-path: "setup.py"
       - name: Install
         run: pip install .
       - name: Install any pre-releases of pystac
@@ -98,3 +98,18 @@ jobs:
         run: pip install -r requirements-dev.txt
       - name: Test
         run: ./scripts/test
+
+  dev-and-docs-requirements:
+    name: dev and docs requirements check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          cache: "pip"
+          cache-dependency-path: "setup.py"
+      - name: Install
+        run: pip install .
+      - name: Install dev and docs requirements
+        run: pip install -r requirements-dev.txt -r requirements-docs.txt

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,7 +30,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
-          cache-dependency-path: "setup.py"
+          cache-dependency-path: |
+            setup.py
+            requirements-dev.txt
 
       - name: Execute linters and test suites
         run: ./scripts/cibuild

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,11 @@ repos:
         args: [--ignore-words=.codespellignore]
         types_or: [jupyter, markdown, python, shell]
   - repo: https://github.com/PyCQA/doc8
-    rev: 0.11.1
+    rev: 0.11.2
     hooks:
       - id: doc8
+        additional_dependencies:
+          - importlib_metadata < 5; python_version == "3.7"
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Dependency conflicts between requirements-dev.txt and requirements-doc.txt [#333](https://github.com/stac-utils/pystac-client/pull/333)
+
 ### Removed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Dependency conflicts between requirements-dev.txt and requirements-doc.txt [#333](https://github.com/stac-utils/pystac-client/pull/333)
 - Some mishandled cases for datetime intervals [#363](https://github.com/stac-utils/pystac-client/pull/363)
 - Collection requests when the Client's url ends in a '/' [#373](https://github.com/stac-utils/pystac-client/pull/373)
 - Parse datetimes more strictly [#364](https://github.com/stac-utils/pystac-client/pull/364)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ pytest-recording~=0.12.1
 pytest-console-scripts~=1.3.1
 recommonmark~=0.7.1
 requests-mock~=1.10.0
-Sphinx~=3.5.1
 
 mypy~=0.981
 types-requests~=2.28.11

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,9 +15,7 @@ codespell~=2.2.2
 
 jsonschema~=4.17.3
 coverage~=6.5
-doc8~=0.11.2
-# https://github.com/PyCQA/doc8/issues/112
-importlib_metadata < 5; python_version == "3.7"
+doc8~=1.0.0
 
 pre-commit==2.20.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,8 @@ codespell~=2.2.1
 jsonschema~=4.6.0
 coverage~=6.5
 doc8~=0.11.2
+# https://github.com/PyCQA/doc8/issues/112
+importlib_metadata < 5; python_version == "3.7"
 
 pre-commit==2.20.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ codespell~=2.2.1
 
 jsonschema~=4.6.0
 coverage~=6.5
-doc8~=1.0.0
+doc8~=0.11.2
 
 pre-commit==2.20.0
 


### PR DESCRIPTION
**Related Issue(s):** 

Prompted by #330, #331, and #332.

- Closes #330 because we remove sphinx from requirements-dev.txt

**Description:**

There were conflicting requirements in the dev and docs requirements.txt files, but this wasn't being caught by CI because dev and docs were never installed at the same time. Rather than polluting an already-existing GH workflow, this commit adds another job to explicitly check. We then add a series of commits to clean up our dependencies.

Includes a fix for a doc8 dependency breakage: https://github.com/PyCQA/doc8/issues/112.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)