### PR TITLE
Fix double-encoding of intersects in GET requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Some mishandled cases for datetime intervals [#363](https://github.com/stac-utils/pystac-client/pull/363)
 - Collection requests when the Client's url ends in a '/' [#373](https://github.com/stac-utils/pystac-client/pull/373)
 - Parse datetimes more strictly [#364](https://github.com/stac-utils/pystac-client/pull/364)
+- Double-encoding of intersects for GET parameters [#337](https://github.com/stac-utils/pystac-client/pull/337)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Python 3.11 support [#347](https://github.com/stac-utils/pystac-client/pull/347)
-- `request_modifier` to `StacApiIO` to allow for additional authentication mechanisms (e.g. AWS SigV4) [#371](https://github.com/stac-utils/pystac-client/issues/371)
-- *Authentication* tutorial, demonstrating how to use to the provided hooks to use both basic and AWS SigV4 authentication [#371](https://github.com/stac-utils/pystac-client/issues/371)
+- `request_modifier` to `StacApiIO` to allow for additional authentication mechanisms (e.g. AWS SigV4) [#372](https://github.com/stac-utils/pystac-client/pull/372)
+- *Authentication* tutorial, demonstrating how to use to the provided hooks to use both basic and AWS SigV4 authentication [#372](https://github.com/stac-utils/pystac-client/pull/372)
 
 ### Changed
 

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -328,7 +328,9 @@ class ItemSearch:
         if "collections" in params:
             params["collections"] = ",".join(params["collections"])
         if "intersects" in params:
-            params["intersects"] = json.dumps(params["intersects"])
+            params["intersects"] = json.dumps(
+                params["intersects"], separators=(",", ":")
+            )
         if "sortby" in params:
             params["sortby"] = self._sortby_dict_to_str(params["sortby"])
         if "fields" in params:

--- a/pystac_client/stac_api_io.py
+++ b/pystac_client/stac_api_io.py
@@ -3,7 +3,7 @@ import logging
 import re
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Union
-from urllib.parse import urlparse
+from urllib.parse import quote_plus, urlparse
 
 import pystac
 from pystac.link import Link
@@ -136,7 +136,7 @@ class StacApiIO(DefaultStacIO):
         else:
             params = deepcopy(parameters) or {}
             if "intersects" in params:
-                params["intersects"] = json.dumps(params["intersects"])
+                params["intersects"] = quote_plus(params["intersects"])
             request = Request(method="GET", url=href, headers=headers, params=params)
         try:
             modified = self._req_modifier(request) if self._req_modifier else None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ pytest-benchmark~=4.0.0
 pytest-cov~=4.0.0
 pytest-recording~=0.12.1
 pytest-console-scripts~=1.3.1
+pytest-httpserver~=1.0.6
 recommonmark~=0.7.1
 requests-mock~=1.10.0
 

--- a/scripts/test
+++ b/scripts/test
@@ -20,7 +20,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         ./scripts/lint
         ./scripts/format
         # Test suite with coverage enabled
-        pytest -Werror -s --block-network --cov pystac_client --cov-report term-missing
+        # The -Wi::pytest.PytestUnraisableExceptionWarning flag is for an ignored exception from pytest-httpserver
+        pytest -Werror -Wi::pytest.PytestUnraisableExceptionWarning -s --block-network --cov pystac_client --cov-report term-missing
         coverage xml
     fi
 fi


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #335 

**Description:**

The stringified intersects dictionary was being double-stringified. This fix uses urllib.parse.quote_plus to urlencode the intersects string for GET requests.

Includes:
- Request parameter assertions using [pytest-httpserver](https://pytest-httpserver.readthedocs.io/en/latest/)
- Denser intersects stringification to increase chance of GET request being short enough

This fix proved hard to test using the existing procedures, because stac-fastapi does not support intersects for GET requests: https://github.com/stac-utils/stac-fastapi/issues/468.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)