### PR TITLE
Terminate on empty page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Python 3.11 support [#347](https://github.com/stac-utils/pystac-client/pull/347)
-- `request_modifier` to `StacApiIO` to allow for additional authentication mechanisms (e.g. AWS SigV4) [#371](https://github.com/stac-utils/pystac-client/issues/371)
-- *Authentication* tutorial, demonstrating how to use to the provided hooks to use both basic and AWS SigV4 authentication [#371](https://github.com/stac-utils/pystac-client/issues/371)
+- `request_modifier` to `StacApiIO` to allow for additional authentication mechanisms (e.g. AWS SigV4) [#372](https://github.com/stac-utils/pystac-client/pull/372)
+- *Authentication* tutorial, demonstrating how to use to the provided hooks to use both basic and AWS SigV4 authentication [#372](https://github.com/stac-utils/pystac-client/pull/372)
 - CI checks for Windows and MacOS [#378](https://github.com/stac-utils/pystac-client/pull/378)
 
 ### Changed
 
 ### Fixed
 
+- Stop iteration on an empty page [#338](https://github.com/stac-utils/pystac-client/pull/338)
 - Some mishandled cases for datetime intervals [#363](https://github.com/stac-utils/pystac-client/pull/363)
 - Collection requests when the Client's url ends in a '/' [#373](https://github.com/stac-utils/pystac-client/pull/373), [#405](https://github.com/stac-utils/pystac-client/pull/405)
 - Parse datetimes more strictly [#364](https://github.com/stac-utils/pystac-client/pull/364)

--- a/pystac_client/stac_api_io.py
+++ b/pystac_client/stac_api_io.py
@@ -227,6 +227,8 @@ class StacApiIO(DefaultStacIO):
             Dict[str, Any] : JSON content from a single page
         """
         page = self.read_json(url, method=method, parameters=parameters)
+        if not (page.get("features") or page.get("collections")):
+            return None
         yield page
 
         next_link = next(
@@ -235,7 +237,7 @@ class StacApiIO(DefaultStacIO):
         while next_link:
             link = Link.from_dict(next_link)
             page = self.read_json(link, parameters=parameters)
-            if not page.get("features", False):
+            if not (page.get("features") or page.get("collections")):
                 return None
             yield page
 

--- a/pystac_client/stac_api_io.py
+++ b/pystac_client/stac_api_io.py
@@ -235,6 +235,8 @@ class StacApiIO(DefaultStacIO):
         while next_link:
             link = Link.from_dict(next_link)
             page = self.read_json(link, parameters=parameters)
+            if not page.get("features", False):
+                return None
             yield page
 
             # get the next link and make the next request


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #334 

**Description:**

Terminate pagination on an empty page.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)