### PR TITLE
Remove python 3.7 support, add Python 3.11 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-#          - "3.11-dev"
+          - "3.11"
         os:
           - ubuntu-latest
 #          - windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Python 3.11 support [#347](https://github.com/stac-utils/pystac-client/pull/347)
+
 ### Changed
 
 ### Fixed
 
 ### Removed
+
+- Python 3.7 support [#347](https://github.com/stac-utils/pystac-client/pull/347)
 
 ### Deprecated
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ Installation
 
    $ pip install pystac-client
 
-``pystac_client`` requires `Python >=3.7 <https://www.python.org/>`__.
+``pystac_client`` requires `Python >=3.8 <https://www.python.org/>`__.
 
 This will install the dependencies :doc:`PySTAC <pystac:index>`,
 :doc:`python-dateutil <dateutil:index>`, and :doc:`requests <requests:index>`.

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -16,6 +16,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Protocol,
     Tuple,
     Union,
 )
@@ -38,10 +39,12 @@ DATETIME_REGEX = re.compile(
     r"(?P<tz_info>Z|([-+])(\d{2}):(\d{2}))?)?)?)?"
 )
 
-# todo: add runtime_checkable when we drop 3.7 support
-# class GeoInterface(Protocol):
-#     def __geo_interface__(self) -> dict:
-#         ...
+
+class GeoInterface(Protocol):
+    @property
+    def __geo_interface__(self) -> Dict[str, Any]:
+        ...
+
 
 DatetimeOrTimestamp = Optional[Union[datetime_, str]]
 Datetime = str
@@ -62,8 +65,7 @@ IDs = Tuple[str, ...]
 IDsLike = Union[IDs, str, List[str], Iterator[str]]
 
 Intersects = Dict[str, Any]
-IntersectsLike = Union[str, object, Intersects]
-# todo: after 3.7 is dropped, replace object with GeoInterface
+IntersectsLike = Union[str, GeoInterface, Intersects]
 
 Query = Dict[str, Any]
 QueryLike = Union[Query, List[str]]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     py_modules=[splitext(basename(path))[0] for path in glob("pystac_client/*.py")],
     include_package_data=True,
     package_data={"pystac_client": ["py.typed"]},
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "requests>=2.27.1",
         "pystac>=1.4.0",
@@ -43,7 +43,6 @@ setup(
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
         "Natural Language :: English",
         "Development Status :: 3 - Alpha",

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -347,7 +347,7 @@ class TestItemSearchParams:
 
     def test_intersects_non_geo_interface_object(self) -> None:
         with pytest.raises(Exception):
-            ItemSearch(url=SEARCH_URL, intersects=object())
+            ItemSearch(url=SEARCH_URL, intersects=object())  # type: ignore
 
     def test_filter_lang_default_for_dict(self) -> None:
         search = ItemSearch(url=SEARCH_URL, filter={})


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #272 
- Closes #339 

**Description:**

Enables our GeoInterface protocol. Currently, there are no changes in **main** other than dependency bumps: https://github.com/stac-utils/pystac-client/blob/1bd3603d38ef7daacca5331f1190dbd766c1c13f/CHANGELOG.md. So we _could_ merge this and release **pystac-client** v0.6.0 as a "remove python 3.7 only" release, ala https://github.com/stac-utils/pystac/releases/tag/v1.6.0. @philvarner @matthewhanson @duckontheweb thoughts?

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)