### PR TITLE
Fix `query` in GET requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
 - Switched to Ruff from isort/flake8 [#457](https://github.com/stac-utils/pystac-client/pull/457)
 - Move to `FutureWarning` from `DeprecationWarning` for item search interface functions that are to be removed [#464](https://github.com/stac-utils/pystac-client/pull/464)
+
+### Fixed
+
+- `query` parameter in GET requests [#362](https://github.com/stac-utils/pystac-client/pull/362)
+- Double encoding of `intersects` parameter in GET requests [#362](https://github.com/stac-utils/pystac-client/pull/362)
 
 ## [v0.6.1] - 2023-03-14
 

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -328,7 +328,11 @@ class ItemSearch:
         if "collections" in params:
             params["collections"] = ",".join(params["collections"])
         if "intersects" in params:
-            params["intersects"] = json.dumps(params["intersects"])
+            params["intersects"] = json.dumps(
+                params["intersects"], separators=(",", ":")
+            )
+        if "query" in params:
+            params["query"] = json.dumps(params["query"], separators=(",", ":"))
         if "sortby" in params:
             params["sortby"] = self._sortby_dict_to_str(params["sortby"])
         if "fields" in params:

--- a/pystac_client/stac_api_io.py
+++ b/pystac_client/stac_api_io.py
@@ -154,8 +154,6 @@ class StacApiIO(DefaultStacIO):
             request = Request(method=method, url=href, headers=headers, json=parameters)
         else:
             params = deepcopy(parameters) or {}
-            if "intersects" in params:
-                params["intersects"] = json.dumps(params["intersects"])
             request = Request(method="GET", url=href, headers=headers, params=params)
         try:
             modified = self._req_modifier(request) if self._req_modifier else None


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #355 

**Description:**

Fixes `query` in GET requests by stringifying the JSON dictionary. Note that (for the Planetary Computer at least) the query parameter _cannot_ be url encoded. @philvarner do you think this is a server bug? If so I can open it on stac-fastapi.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)