### PR TITLE
Parse datetimes more strictly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Some mishandled cases for datetime intervals [#363](https://github.com/stac-utils/pystac-client/pull/363)
+- Parse datetimes more strictly [#364](https://github.com/stac-utils/pystac-client/pull/364)
 
 ### Removed
 

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -34,9 +34,9 @@ if TYPE_CHECKING:
     from pystac_client import client as _client
 
 DATETIME_REGEX = re.compile(
-    r"(?P<year>\d{4})(-(?P<month>\d{2})(-(?P<day>\d{2})"
+    r"^(?P<year>\d{4})(-(?P<month>\d{2})(-(?P<day>\d{2})"
     r"(?P<remainder>([Tt])\d{2}:\d{2}:\d{2}(\.\d+)?"
-    r"(?P<tz_info>Z|([-+])(\d{2}):(\d{2}))?)?)?)?"
+    r"(?P<tz_info>[Zz]|([-+])(\d{2}):(\d{2}))?)?)?)?$"
 )
 
 

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -276,6 +276,10 @@ class TestItemSearchParams:
         with pytest.raises(Exception):
             ItemSearch(url=SEARCH_URL, datetime=[None])
 
+    def test_poorly_formed_datetimes(self) -> None:
+        with pytest.raises(Exception):
+            ItemSearch(url=SEARCH_URL, datetime="2020-7/2020-8")
+
     def test_single_collection_string(self) -> None:
         # Single ID string
         search = ItemSearch(url=SEARCH_URL, collections="naip")


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #358 


**Description:**

The whole string must now match the regex. Includes a tweak to the regex to match a valid string that was being missed before.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)