### PR TITLE
Downgrade ipykernel

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-ipykernel~=6.18
+ipykernel~=6.17
 ipython~=8.7
 Sphinx~=5.3
 sphinxcontrib-fulltoc~=1.2


### PR DESCRIPTION
**Description:**

As of 2022-11-30, all 6.18 versions have been yanked from PyPI, breaking CI: https://pypi.org/project/ipykernel/#history.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)