### PR TITLE
Ensure client self hrefs don't end in '/'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Some mishandled cases for datetime intervals [#363](https://github.com/stac-utils/pystac-client/pull/363)
+- Collection requests when the Client's url ends in a '/' [#373](https://github.com/stac-utils/pystac-client/pull/373)
 
 ### Removed
 

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -132,8 +132,7 @@ class Client(pystac.Catalog):
         Return:
             catalog : A :class:`Client` instance for this Catalog/API
         """
-        if url.endswith("/"):
-            url = url[0:-1]
+        url = url.rstrip("/")
         client: Client = cls.from_file(
             url, headers=headers, parameters=parameters, modifier=modifier
         )

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -132,6 +132,8 @@ class Client(pystac.Catalog):
         Return:
             catalog : A :class:`Client` instance for this Catalog/API
         """
+        if url.endswith("/"):
+            url = url[0:-1]
         client: Client = cls.from_file(
             url, headers=headers, parameters=parameters, modifier=modifier
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -128,6 +128,24 @@ class TestAPI:
         assert len(history) == 2
         assert history[1].url == collections_link.href
 
+    def test_get_collections_single_slash(self, requests_mock: Mocker) -> None:
+        pc_root_text = read_data_file("planetary-computer-root.json")
+        root_url = "http://pystac-client.test/"
+        requests_mock.get(root_url, status_code=200, text=pc_root_text)
+        api = Client.open(root_url)
+        pc_collection_dict = read_data_file(
+            "planetary-computer-aster-l1t-collection.json", parse_json=True
+        )
+        requests_mock.get(
+            f"{root_url}collections",  # note the lack of the slash
+            status_code=200,
+            json={"collections": [pc_collection_dict], "links": []},
+        )
+        _ = next(api.get_collections())
+        history = requests_mock.request_history
+        assert len(history) == 2
+        assert history[1].url == f"{root_url}collections"
+
     def test_custom_request_parameters(self, requests_mock: Mocker) -> None:
         pc_root_text = read_data_file("planetary-computer-root.json")
         pc_collection_dict = read_data_file(


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #369 

**Description:**

Our url construction is a bit naïve -- we use basic string formatting, e.g. https://github.com/stac-utils/pystac-client/blob/3f305e287ceb6ad966da278e5ee4abf4f79f1a04/pystac_client/client.py#L257

As raised in #369, this can lead to request urls containing double `//`, which breaks some APIs (e.g. out-of-the-box **stac-fastapi**). This PR does the simplest-possible fix by ensuring that a `Client`'s self href doesn't end in a slash.


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)