### PR TITLE
Bump isort in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
**Related Issue(s):** 

- Picks up https://github.com/PyCQA/isort/pull/2078


**Description:**

CI was broken b/c **isort** building got broken by a **poetry-core** update. 🥳 


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)