### PR TITLE
Fix fail when header has more than one equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix parse fail when header has multiple '=' characters [#440](https://github.com/stac-utils/pystac-client/pull/440)
+
 ## [v0.6.0] - 2023-01-27
 
 ### Added

--- a/pystac_client/cli.py
+++ b/pystac_client/cli.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import sys
 from typing import Any, Dict, List, Optional
 
@@ -191,10 +192,11 @@ def parse_args(args: List[str]) -> Dict[str, Any]:
     # if headers provided, parse it
     if "headers" in parsed_args:
         new_headers = {}
+        splitter = re.compile("^([^=]+)=(.+)$")
         for head in parsed_args["headers"]:
-            parts = head.split("=")
-            if len(parts) == 2:
-                new_headers[parts[0]] = parts[1]
+            match = splitter.match(head)
+            if match:
+                new_headers[match.group(1)] = match.group(2)
             else:
                 logger.warning(f"Unable to parse header {head}")
         parsed_args["headers"] = new_headers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,9 @@
+from typing import List
+
 import pytest
 from pytest_console_scripts import ScriptRunner
 
+import pystac_client.cli
 from tests.helpers import STAC_URLS
 
 
@@ -18,6 +21,30 @@ class TestCLI:
         ]
         result = script_runner.run(*args, print_result=False)
         assert result.success
+
+    @pytest.mark.parametrize(
+        "headers,good_header_count",
+        [
+            (["kick=flip", "home=run"], 2),
+            (["mad=pow"], 1),
+            (["=no-var"], 0),
+            (["no-val="], 0),
+            (["good=header", "bad-header"], 1),
+            (["header=value-with-three-=-signs-=", "plain=jane"], 2),
+        ],
+    )
+    def test_headers(self, headers: List[str], good_header_count: int) -> None:
+        args = [
+            "search",
+            STAC_URLS["PLANETARY-COMPUTER"],
+            "-c",
+            "naip",
+            "--max-items",
+            "20",
+            "--headers",
+        ] + headers
+        pargs = pystac_client.cli.parse_args(args)
+        assert len(pargs["headers"]) == good_header_count
 
     def test_no_arguments(self, script_runner: ScriptRunner) -> None:
         args = ["stac-client"]


### PR DESCRIPTION
**Related Issue(s):** 

- No ticket


**Description:**
Adding a header from the CLI failed to parse if there was more than one equal sign (`=`).  This fixes that, and adds a test which demonstrates the improvement.

**PR Checklist:**

- [X] Code is formatted
- [X] Tests pass
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)