### PR TITLE
Bump pystac version, remove some type: ignores, and do some other linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped PySTAC dependency to >= 1.7.0 [#449](https://github.com/stac-utils/pystac-client/pull/449)
+
 ### Fixed
 
 - Fix parse fail when header has multiple '=' characters [#440](https://github.com/stac-utils/pystac-client/pull/440)

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -1,15 +1,5 @@
 from functools import lru_cache
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Union
 
 import pystac
 import pystac.utils
@@ -204,7 +194,7 @@ class Client(pystac.Catalog):
                 request_modifier=request_modifier,
             )
 
-        client: Client = super().from_file(href, stac_io)  # type: ignore
+        client: Client = super().from_file(href, stac_io)
 
         client._stac_io._conformance = client.extra_fields.get(  # type: ignore
             "conformsTo", []
@@ -241,10 +231,6 @@ class Client(pystac.Catalog):
                 f"Could not open Client (href={href}), "
                 f"expected type=Catalog, found type={d.get('type', None)}"
             )
-        # cast require for mypy to believe that we have a Client, rather than
-        # the super type.
-        # https://github.com/stac-utils/pystac/issues/862
-        result = cast(Client, result)
 
         result.modifier = modifier
         return result

--- a/pystac_client/collection_client.py
+++ b/pystac_client/collection_client.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
 
 
 class CollectionClient(pystac.Collection):
-
     modifier: Callable[[Modifiable], None]
     _stac_io: Optional[StacApiIO]
 
@@ -69,8 +68,7 @@ class CollectionClient(pystac.Collection):
         # error: Cannot assign to a method  [assignment]
         # https://github.com/python/mypy/issues/2427
         setattr(result, "modifier", modifier)
-        # ignore the return type: https://github.com/stac-utils/pystac/issues/862
-        return result  # type: ignore
+        return result
 
     def __repr__(self) -> str:
         return "<CollectionClient id={}>".format(self.id)

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,3 +1,3 @@
 requests==2.28.2
-pystac==1.4.0
+pystac==1.7.0
 python-dateutil==2.7.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "requests>=2.27.1",
-        "pystac>=1.4.0",
+        "pystac>=1.7.0",
         "python-dateutil>=2.7.0",
     ],
     extras_require={"validation": ["jsonschema>=4.5.1"]},

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -34,8 +34,9 @@ ITEM_EXAMPLE: Dict[str, Any] = {"collections": "io-lulc", "ids": "60U-2020"}
 class TestItemPerformance:
     @pytest.fixture(scope="function")
     def single_href(self) -> str:
-        item_href = "https://planetarycomputer.microsoft.com/api/stac/v1/collections/{collections}/items/{ids}".format(
-            collections=ITEM_EXAMPLE["collections"], ids=ITEM_EXAMPLE["ids"]
+        item_href = (
+            "https://planetarycomputer.microsoft.com/api/stac/v1/collections/"
+            f"{ITEM_EXAMPLE['collections']}/items/{ITEM_EXAMPLE['ids']}"
         )
         return item_href
 
@@ -457,7 +458,6 @@ class TestItemSearchParams:
             ItemSearch(url=SEARCH_URL, sortby=[1])  # type: ignore
 
     def test_fields(self) -> None:
-
         with pytest.raises(Exception):
             ItemSearch(url=SEARCH_URL, fields=1)  # type: ignore
 
@@ -629,7 +629,8 @@ class TestItemSearch:
             max_items=20,
         )
 
-        # Check that the current page changes on the ItemSearch instance when a new page is requested
+        # Check that the current page changes on the ItemSearch instance when a new page
+        # is requested
         pages = list(search.pages())
 
         assert pages[1] != pages[2]
@@ -725,7 +726,6 @@ class TestItemSearchQuery:
 
     @pytest.mark.vcr
     def test_query_json_syntax(self) -> None:
-
         # with a list of json strs (format of CLI argument to ItemSearch)
         search = ItemSearch(
             url=SEARCH_URL,


### PR DESCRIPTION
**Description:**

pystac 1.7.0 made these unnecessary

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)