### PR TITLE
Swap out isort/flake8 in favor of ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,15 +19,10 @@ repos:
         args: [--ignore=D004]
         additional_dependencies:
           - importlib_metadata < 5; python_version == "3.7"
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.257'
     hooks:
-      - id: flake8
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
+    - id: ruff
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.991
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Switched to Ruff from isort/flake8 [#457](https://github.com/stac-utils/pystac-client/pull/457)
+
 ## [v0.6.1] - 2023-03-14
 
 ### Changed

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -57,7 +57,7 @@ PySTAC-Client uses
 - `black <https://github.com/psf/black>`_ for Python code formatting
 - `codespell <https://github.com/codespell-project/codespell/>`_ to check code for common misspellings
 - `doc8 <https://github.com/pycqa/doc8>`__ for style checking on RST files in the docs
-- `flake8 <https://flake8.pycqa.org/en/latest/>`_ for Python style checks
+- `ruff <https://beta.ruff.rs/docs/>`_ for Python style checks
 - `mypy <http://www.mypy-lang.org/>`_ for Python type annotation checks
 
 Run all of these with ``pre-commit run --all-files`` or a single one using

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.ruff]
+ignore = [
+    "E722",
+    "E731",
+]
+line-length = 88
+select = [
+    "E",
+    "F",
+    "W",
+]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]
+"test_item_search.py" = ["E501"]

--- a/pystac_client/__init__.py
+++ b/pystac_client/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 __all__ = [
     "Client",
     "CollectionClient",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ requests-mock~=1.10.0
 mypy~=1.1
 types-requests~=2.28.11
 types-python-dateutil~=2.8.19
-flake8~=6.0.0
+ruff==0.0.257
 black~=23.1.0
 codespell~=2.2.4
 

--- a/scripts/format
+++ b/scripts/format
@@ -18,6 +18,5 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         pre-commit run black --all-files
-        pre-commit run isort --all-files
     fi
 fi

--- a/scripts/lint
+++ b/scripts/lint
@@ -19,7 +19,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     else
         pre-commit run codespell --all-files
         pre-commit run doc8 --all-files
-        pre-commit run flake8 --all-files
+        pre-commit run ruff --all-files
         pre-commit run mypy --all-files
     fi
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,17 +1,9 @@
 [metadata]
 license_file = LICENSE
 
-[isort]
-profile=black
-
 [doc8]
 ignore-path=docs/_build,docs/tutorials
 max-line-length=130
-
-[flake8]
-max-line-length = 88
-extend-ignore = E203, W503, E731, E722
-per-file-ignores = __init__.py:F401,test_item_search.py:E501
 
 [tool:pytest]
 markers =


### PR DESCRIPTION
**Related Issue(s):** 
Closes #452

**Description:**
This PR replaces isort and flake8 with Ruff, and attempts to configure Ruff to match the previous configuration of flake.  Note that [E203](https://www.flake8rules.com/rules/E203.html) and [W503](https://www.flake8rules.com/rules/W503.html) are not supported by Ruff, though these were in the ignore column, so this shouldn't matter.

**PR Checklist:**

- [ ] Code is formatted
- [ ] Tests pass
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)