### PR TITLE
Convert DeprecationWarning to FutureWarning for item search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 - Switched to Ruff from isort/flake8 [#457](https://github.com/stac-utils/pystac-client/pull/457)
+- Move to `FutureWarning` from `DeprecationWarning` for item search interface functions that are to be removed [#464](https://github.com/stac-utils/pystac-client/pull/464)
 
 ## [v0.6.1] - 2023-03-14
 

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -793,7 +793,7 @@ class ItemSearch:
         """
         warnings.warn(
             "get_item_collections() is deprecated, use pages() instead",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.pages()
 
@@ -809,7 +809,7 @@ class ItemSearch:
         """
         warnings.warn(
             "item_collections() is deprecated, use pages() instead",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.pages()
 
@@ -824,7 +824,7 @@ class ItemSearch:
         """
         warnings.warn(
             "get_items() is deprecated, use items() instead",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.items()
 
@@ -839,7 +839,7 @@ class ItemSearch:
         """
         warnings.warn(
             "get_all_items() is deprecated, use item_collection() instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.item_collection()
 
@@ -855,6 +855,6 @@ class ItemSearch:
         warnings.warn(
             "get_all_items_as_dict() is deprecated, use item_collection_as_dict() "
             "instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.item_collection_as_dict()

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -671,7 +671,7 @@ class TestItemSearch:
             max_items=20,
         )
 
-        with pytest.warns(DeprecationWarning, match=method):
+        with pytest.warns(FutureWarning, match=method):
             result = operator.methodcaller(method)(search)
 
         expected = operator.methodcaller(alternative)(search)


### PR DESCRIPTION
**Related Issue(s):** 
- Closes #295 

**Description:**
A PR to convert to a more user-facing deprecation warning type, `FutureWarning`, for API functions that will be removed soon.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)