### PR TITLE
Fail on CI if tutorial notebooks raise errors

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
+          python-version: 3.9
           use-mamba: true
           channel-priority: strict
           environment-file: ./docs/environment.yml

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -94,7 +94,7 @@ jobs:
           activate-environment: pystac-client-docs
           auto-activate-base: false
       - name: Build docs
-        run: ./scripts/build-docs
+        run: sphinx-build -M html docs docs/build
 
   pre-release:
     name: pre-release

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -80,6 +80,10 @@ jobs:
   docs:
     name: docs
     runs-on: ubuntu-latest
+    # Required shell entrypoint to have properly activated conda environment
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Conda Environment
@@ -94,9 +98,9 @@ jobs:
           activate-environment: pystac-client-docs
           auto-activate-base: false
       - name: List environment
-        run: source mamba list
+        run: mamba list
       - name: Build docs
-        run: source ./scripts/docs
+        run: ./scripts/docs
 
   pre-release:
     name: pre-release

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,7 +78,6 @@ jobs:
         run: ./scripts/test
 
   docs:
-    if: matrix.python-version != "3.11"
     name: docs
     runs-on: ubuntu-latest
     steps:
@@ -89,7 +88,6 @@ jobs:
           miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
-          python-version: ${{ matrix.python-version }}
           channel-priority: strict
           environment-file: ./docs/environment.yml
           activate-environment: pystac-client-docs

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -97,10 +97,8 @@ jobs:
           environment-file: ./docs/environment.yml
           activate-environment: pystac-client-docs
           auto-activate-base: false
-      - name: List environment
-        run: mamba list
       - name: Build docs
-        run: ./scripts/docs
+        run: ./scripts/build-docs
 
   pre-release:
     name: pre-release

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,21 +78,22 @@ jobs:
         run: ./scripts/test
 
   docs:
+    if: matrix.python-version != "3.11"
     name: docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - name: Setup Conda Environment
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
-          python-version: 3.9
-          cache: "pip"
-          cache-dependency-path: "requirements-docs.txt"
-      - name: Install pandoc
-        run: sudo apt-get update && sudo apt-get -y install pandoc
-      - name: Install docs requirements
-        run: pip install -r requirements-docs.txt
-      - name: Install pystac_client
-        run: pip install .
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          python-version: ${{ matrix.python-version }}
+          channel-priority: strict
+          environment-file: ./docs/environment.yml
+          activate-environment: pystac-client-docs
+          auto-activate-base: false
       - name: Build docs
         run: ./scripts/build-docs
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -94,7 +94,9 @@ jobs:
           activate-environment: pystac-client-docs
           auto-activate-base: false
       - name: Build docs
-        run: sphinx-build -M html docs docs/build
+        run: |
+          source mamba list
+          source ./scripts/docs
 
   pre-release:
     name: pre-release

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -93,10 +93,10 @@ jobs:
           environment-file: ./docs/environment.yml
           activate-environment: pystac-client-docs
           auto-activate-base: false
+      - name: List environment
+        run: source mamba list
       - name: Build docs
-        run: |
-          source mamba list
-          source ./scripts/docs
+        run: source ./scripts/docs
 
   pre-release:
     name: pre-release

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ extlinks = {
     )
 }
 
-nbsphinx_allow_errors = True
+nbsphinx_allow_errors = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,7 +3,11 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.8
+  - cartopy
+  - geoviews
+  - pandoc
+  - python=3.9
+  - pip
   - pip:
     - -r ../requirements-docs.txt
     - -e ../

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -17,6 +17,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        sphinx-build -M html docs docs/build
+        python -m sphinx -T -E -b html docs docs/build
     fi
 fi

--- a/scripts/build-docs
+++ b/scripts/build-docs
@@ -17,6 +17,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        python -m sphinx -T -E -b html docs docs/build
+        sphinx-build -M html docs docs/build
     fi
 fi


### PR DESCRIPTION
**Related Issue(s):** 

- #488 


**Description:**

Switch CI to use conda env in same as on read-the-docs, add missing conda-only dependencies to env, flip `nbsphinx_allow_errors` to False.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)