### PR TITLE
Don't unquote in url_with_parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix geometry instantiation in item-search-intersects.ipynb [#484](https://github.com/stac-utils/pystac-client/pull/484)
 - Three tests that were false positives due to out-of-date cassettes [#491](https://github.com/stac-utils/pystac-client/pull/491)
 - Max items checks when paging [#492](https://github.com/stac-utils/pystac-client/pull/492)
+- `ItemSearch.url_with_parameters` no longer unquotes the url [#530](https://github.com/stac-utils/pystac-client/pull/530)
 
 ### Removed
 

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -1,6 +1,5 @@
 import json
 import re
-import urllib.parse
 import warnings
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
@@ -362,7 +361,7 @@ class ItemSearch:
         url = request.prepare().url
         if url is None:
             raise ValueError("Could not construct a full url")
-        return urllib.parse.unquote(url)
+        return url
 
     def _format_query(self, value: Optional[QueryLike]) -> Optional[Dict[str, Any]]:
         if value is None:


### PR DESCRIPTION
**Related Issue(s):** 

- Discovered while checking #522 
- Closes #522 as invalid

**Description:**

I think #522 is invalid, I was not able to reproduce. I added a test case to prove it. While checking, I discovered that `url_with_parameters` was unquoting the url, which I think is incorrect. Fixed that, and fixed the tests.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)