### PR TITLE
Include Modifiable at the top-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - PySTAC Client specific warnings [#480](https://github.com/stac-utils/pystac-client/pull/480)
 - Support for fetching and merging a selection of queryables [#511](https://github.com/stac-utils/pystac-client/pull/511)
 - Better error messages for the CLI [#531](https://github.com/stac-utils/pystac-client/pull/531)
+- `Modifiable` to our public API [#534](https://github.com/stac-utils/pystac-client/pull/534)
 
 ### Changed
 

--- a/pystac_client/__init__.py
+++ b/pystac_client/__init__.py
@@ -3,9 +3,11 @@ __all__ = [
     "CollectionClient",
     "ConformanceClasses",
     "ItemSearch",
+    "Modifiable",
     "__version__",
 ]
 
+from pystac_client._utils import Modifiable
 from pystac_client.client import Client
 from pystac_client.collection_client import CollectionClient
 from pystac_client.conformance import ConformanceClasses


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #533 


**Description:**

We use `Modifiable` in the signature of `Client.open()` (among other places) so it should be "public".

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)