### PR TITLE
Tighten the Timeout type to non-optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Timeout option added to `Client.open` [#463](https://github.com/stac-utils/pystac-client/pull/463)
+- Timeout option added to `Client.open` [#463](https://github.com/stac-utils/pystac-client/pull/463), [#538](https://github.com/stac-utils/pystac-client/pull/538)
 - Support for fetching catalog queryables [#477](https://github.com/stac-utils/pystac-client/pull/477)
 - PySTAC Client specific warnings [#480](https://github.com/stac-utils/pystac-client/pull/480)
 - Support for fetching and merging a selection of queryables [#511](https://github.com/stac-utils/pystac-client/pull/511)

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -101,7 +101,7 @@ class Client(pystac.Catalog, QueryablesMixin):
         modifier: Optional[Callable[[Modifiable], None]] = None,
         request_modifier: Optional[Callable[[Request], Union[Request, None]]] = None,
         stac_io: Optional[StacApiIO] = None,
-        timeout: Timeout = None,
+        timeout: Optional[Timeout] = None,
     ) -> "Client":
         """Opens a STAC Catalog or API
         This function will read the root catalog of a STAC Catalog or API
@@ -197,7 +197,7 @@ class Client(pystac.Catalog, QueryablesMixin):
         parameters: Optional[Dict[str, Any]] = None,
         modifier: Optional[Callable[[Modifiable], None]] = None,
         request_modifier: Optional[Callable[[Request], Union[Request, None]]] = None,
-        timeout: Timeout = None,
+        timeout: Optional[Timeout] = None,
     ) -> "Client":
         """Open a STAC Catalog/API
 

--- a/pystac_client/stac_api_io.py
+++ b/pystac_client/stac_api_io.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-Timeout: TypeAlias = Optional[Union[float, Tuple[float, float], Tuple[float, None]]]
+Timeout: TypeAlias = Union[float, Tuple[float, float], Tuple[float, None]]
 
 
 class StacApiIO(DefaultStacIO):
@@ -49,7 +49,7 @@ class StacApiIO(DefaultStacIO):
         conformance: Optional[List[str]] = None,
         parameters: Optional[Dict[str, Any]] = None,
         request_modifier: Optional[Callable[[Request], Union[Request, None]]] = None,
-        timeout: Timeout = None,
+        timeout: Optional[Timeout] = None,
         max_retries: Optional[int] = 5,
     ):
         """Initialize class for API IO
@@ -104,7 +104,7 @@ class StacApiIO(DefaultStacIO):
         headers: Optional[Dict[str, str]] = None,
         parameters: Optional[Dict[str, Any]] = None,
         request_modifier: Optional[Callable[[Request], Union[Request, None]]] = None,
-        timeout: Timeout = None,
+        timeout: Optional[Timeout] = None,
     ) -> None:
         """Updates this StacApi's headers, parameters, and/or request_modifer.
 


### PR DESCRIPTION


**Related Issue(s):** 

- Discovered when I was doing a final backwards-comparability-and-API-additions check for #537 

**Description:**

The type itself should be non-optional, and functions/methods should declare whether they need a timeout or whether it's optional.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)