### PR TITLE
Add `Retry` type hint to `StacApiIO`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Raise more informative errors from CLI [#554](https://github.com/stac-utils/pystac-client/pull/554)
+- Add `Retry` type hint to `StacApiIO` [#577](https://github.com/stac-utils/pystac-client/pull/577)
 
 ### Fixed
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -134,8 +134,7 @@ If you'd like to configure this behavior, e.g. to retry on some ``50x`` response
     retry = Retry(
         total=5, backoff_factor=1, status_forcelist=[502, 503, 504], allowed_methods=None
     )
-    stac_api_io = StacApiIO()
-    stac_api_io.session.mount("https://", HTTPAdapter(max_retries=retry))
+    stac_api_io = StacApiIO(max_retries=retry)
     client = Client.open(
         "https://planetarycomputer.microsoft.com/api/stac/v1", stac_io=stac_api_io
     )

--- a/pystac_client/stac_api_io.py
+++ b/pystac_client/stac_api_io.py
@@ -26,6 +26,7 @@ from pystac.serialization import (
 from pystac.stac_io import DefaultStacIO
 from requests import Request, Session
 from requests.adapters import HTTPAdapter
+from urllib3 import Retry
 
 import pystac_client
 
@@ -49,7 +50,7 @@ class StacApiIO(DefaultStacIO):
         parameters: Optional[Dict[str, Any]] = None,
         request_modifier: Optional[Callable[[Request], Union[Request, None]]] = None,
         timeout: Optional[Timeout] = None,
-        max_retries: Optional[int] = 5,
+        max_retries: Optional[Union[int, Retry]] = 5,
     ):
         """Initialize class for API IO
 


### PR DESCRIPTION
Add `Retry` type hint so that a retry object so that the `HTTPAdapter`s are correctly mounted.

**Related Issue(s):** 

- #576 


**Description:**

Add `Retry` type hint to `StacApiIO`.


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)