### PR TITLE
Fix trove classifier for license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Natural Language :: English",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
The trove classifier for license indicates MIT, and it is clearly inconsistent with the `license` field in `pyproject.toml` and with the `LICENSE` file itself.

The proposed patch fixes the inconsistency.