### PR TITLE
Fix typo in contributing documentation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -13,7 +13,7 @@ the library as an "editable link", then install the development dependencies:
 .. code-block:: bash
 
     $ git clone git@github.com:your_user_name/pystac-client.git
-    $ cd  pystac
+    $ cd pystac-client
     $ pip install -e '.[dev]'
 
 Testing


### PR DESCRIPTION
**Related Issue(s):** None

**Description:** Fixed minor typo in development installation instructions in contributing guide

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [ ] ~~Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)~~ (N/A for typo)