### PR TITLE
Don't treat warnings as errors.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ select = ["E", "F", "W", "I"]
 
 [tool.pytest.ini_options]
 markers = "vcr: records network activity"
-addopts = "--benchmark-skip -Werror --block-network"
+addopts = "--benchmark-skip --block-network"
 
 [tool.mypy]
 show_error_codes = true


### PR DESCRIPTION
Using -Werror in CI is good, it is not a good default for downstream distributions where new warnings by toolchain updates causes the build to fail.

Importing dateutil.parser causes a DeprecationWarning:
```
  /usr/lib/python3/dist-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)
```