### PR TITLE
Update to pystac v1.10

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,10 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         os:
           - ubuntu-latest
           - windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Updated to **pystac** v1.10.0 [#661](https://github.com/stac-utils/pystac-client/pull/661)
+
 ## [v0.7.6]
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "requests>=2.28.2",
-    "pystac[validation]>=1.8.2",
+    "pystac[validation]>=1.10.0",
     "python-dateutil>=2.8.2",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ license = { text = "Apache-2.0" }
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
     "Natural Language :: English",
     "Development Status :: 4 - Beta",

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -17,6 +17,7 @@ import pystac
 import pystac.utils
 import pystac.validation
 from pystac import CatalogType, Collection
+from pystac.layout import HrefLayoutStrategy
 from requests import Request
 
 from pystac_client._utils import Modifiable, call_modifier
@@ -71,6 +72,7 @@ class Client(pystac.Catalog, QueryablesMixin):
         extra_fields: Optional[Dict[str, Any]] = None,
         href: Optional[str] = None,
         catalog_type: CatalogType = CatalogType.ABSOLUTE_PUBLISHED,
+        strategy: Optional[HrefLayoutStrategy] = None,
         *,
         modifier: Optional[Callable[[Modifiable], None]] = None,
         **kwargs: Dict[str, Any],
@@ -83,6 +85,7 @@ class Client(pystac.Catalog, QueryablesMixin):
             extra_fields=extra_fields,
             href=href,
             catalog_type=catalog_type,
+            strategy=strategy,
             **kwargs,
         )
         self.modifier = modifier

--- a/pystac_client/collection_client.py
+++ b/pystac_client/collection_client.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 import pystac
+import pystac.layout
 
 from pystac_client._utils import Modifiable, call_modifier
 from pystac_client.conformance import ConformanceClasses
@@ -47,11 +48,12 @@ class CollectionClient(pystac.Collection, QueryablesMixin):
         keywords: Optional[List[str]] = None,
         providers: Optional[List[pystac.Provider]] = None,
         summaries: Optional[pystac.Summaries] = None,
+        assets: Optional[Dict[str, pystac.Asset]] = None,
+        strategy: Optional[pystac.layout.HrefLayoutStrategy] = None,
         *,
         modifier: Optional[Callable[[Modifiable], None]] = None,
         **kwargs: Dict[str, Any],
     ):
-        # TODO(pystac==1.6.0): Add `assets` as a regular keyword
         super().__init__(
             id,
             description,
@@ -65,6 +67,8 @@ class CollectionClient(pystac.Collection, QueryablesMixin):
             keywords,
             providers,
             summaries,
+            assets,
+            strategy,
             **kwargs,
         )
         # error: Cannot assign to a method  [assignment]


### PR DESCRIPTION
**Related Issue(s):** 

- Fixed the typing issues that popped up in https://github.com/stac-utils/pystac-client/pull/660

**Discussion:**

Also drops Python 3.8 (because PySTAC did) and add Python 3.12.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)
- [x] When approved, update the required status checks in Github