### PR TITLE
Verify requests with REQUESTS_CA_BUNDLE if set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Updated to **pystac** v1.10.0 [#661](https://github.com/stac-utils/pystac-client/pull/661)
 - Use [uv](https://github.com/astral-sh/uv) for CI [#663](https://github.com/stac-utils/pystac-client/pull/663)
+- If set, use `requests`'s `REQUESTS_CA_BUNDLE` environment variable to verify HTTPS requests [#655](https://github.com/stac-utils/pystac-client/pull/665)
 
 ## [v0.7.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Updated to **pystac** v1.10.0 [#661](https://github.com/stac-utils/pystac-client/pull/661)
 - Use [uv](https://github.com/astral-sh/uv) for CI [#663](https://github.com/stac-utils/pystac-client/pull/663)
-- If set, use `requests`'s `REQUESTS_CA_BUNDLE` environment variable to verify HTTPS requests [#655](https://github.com/stac-utils/pystac-client/pull/665)
+- If set, use `requests`'s `REQUESTS_CA_BUNDLE` environment variable and `CURL_CA_BUNDLE` fallback to verify HTTPS requests [#655](https://github.com/stac-utils/pystac-client/pull/665)
 
 ## [v0.7.6]
 

--- a/pystac_client/stac_api_io.py
+++ b/pystac_client/stac_api_io.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import warnings
 from copy import deepcopy
 from typing import (
@@ -40,6 +41,8 @@ logger = logging.getLogger(__name__)
 
 
 Timeout = Union[float, Tuple[float, float], Tuple[float, None]]
+
+REQUESTS_CA_BUNDLE = os.environ.get("REQUESTS_CA_BUNDLE")
 
 
 class StacApiIO(DefaultStacIO):
@@ -209,7 +212,12 @@ class StacApiIO(DefaultStacIO):
             if self.timeout is not None:
                 msg += f" Timeout: {self.timeout}"
             logger.debug(msg)
-            resp = self.session.send(prepped, timeout=self.timeout)
+            if REQUESTS_CA_BUNDLE:
+                resp = self.session.send(
+                    prepped, timeout=self.timeout, verify=REQUESTS_CA_BUNDLE
+                )
+            else:
+                resp = self.session.send(prepped, timeout=self.timeout)
         except Exception as err:
             logger.debug(err)
             raise APIError(str(err))


### PR DESCRIPTION
**Related Issue(s):** 

- #664 


**Description:** By default, the basic `requests.get`, `requests.post`, etc., functions look for an environment variable `REQUESTS_CA_BUNDLE` (see [docs](https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification)), which can point to a custom certificate bundle file instead of the default bundle provided with `certifi`. This is common practice in e.g., corporate settings where HTTPS inspection is being performed with SSL certificate replacement, causing HTTPS responses with odd-looking certificates. This PR ensures that `pystac-client` also respects the `REQUESTS_CA_BUNDLE` environment variable.


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)