### PR TITLE
Allow requests to respect the environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use [uv](https://github.com/astral-sh/uv) for CI [#663](https://github.com/stac-utils/pystac-client/pull/663)
 - use `APILayoutStrategy` as fallback strategy [#666](https://github.com/stac-utils/pystac-client/pull/666)
 
+### Fixed
+
+- Respect the `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` environment variables when sending requests [#669](https://github.com/stac-utils/pystac-client/pull/669)
+
 ## [v0.7.6]
 
 ### Fixed

--- a/pystac_client/stac_api_io.py
+++ b/pystac_client/stac_api_io.py
@@ -209,7 +209,10 @@ class StacApiIO(DefaultStacIO):
             if self.timeout is not None:
                 msg += f" Timeout: {self.timeout}"
             logger.debug(msg)
-            resp = self.session.send(prepped, timeout=self.timeout)
+            send_kwargs = self.session.merge_environment_settings(
+                prepped.url, proxies={}, stream=None, verify=True, cert=None
+            )
+            resp = self.session.send(prepped, timeout=self.timeout, **send_kwargs)
         except Exception as err:
             logger.debug(err)
             raise APIError(str(err))


### PR DESCRIPTION

**Related Issue(s):** 

- Closes #664 
- Supersedes #665 

**Description:**

When reviewing #665, it felt like we shoud use **requests** environment lookup logic instead of duplicating it in **pystac-client**. This PR implements that.

This PR sort of suggests that we should expose more attributes on the `StacApiIO` (e.g. `verify`) to further configure behavior, but that can be done in a follow-on PR if we want.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)