### PR TITLE
Exclude macos and python 3.9

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,6 +27,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        exclude:  # macos-latest is arm64, which doesn't have this python
+          - os: macos-latest
+            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
**Related Issue(s):** 

- Should unblock #673


**Description:**

Since `macos-latest` is now arm64, we don't have python 3.9 available.
No changelog needed.


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] (once approved) remove macos 3.9 from the required checks