### PR TITLE
Use versioning-strategy increase-if-necessary

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,4 @@ updates:
     directory: "."
     schedule:
       interval: daily
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
**Description:**

It's a little thing, but I think this will get it to respect `~=` in our `pyproject.toml`, per https://github.com/dependabot/dependabot-core/issues/1440 and https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy. No CHANGELOG entry required.


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass