### PR TITLE
Use singular field key names: `include` and `exclude`

### DIFF
--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -633,12 +633,12 @@ class ItemSearch:
                 includes.append(field[1:])
             else:
                 includes.append(field)
-        return {"includes": includes, "excludes": excludes}
+        return {"include": includes, "exclude": excludes}
 
     @staticmethod
     def _fields_dict_to_str(fields: Fields) -> str:
-        includes = [f"+{x}" for x in fields.get("includes", [])]
-        excludes = [f"-{x}" for x in fields.get("excludes", [])]
+        includes = [f"+{x}" for x in fields.get("include", [])]
+        excludes = [f"-{x}" for x in fields.get("exclude", [])]
         return ",".join(chain(includes, excludes))
 
     @staticmethod

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -468,23 +468,23 @@ class TestItemSearchParams:
 
         search = ItemSearch(url=SEARCH_URL, fields="id,collection,+foo,-bar")
         assert search.get_parameters()["fields"] == {
-            "excludes": ["bar"],
-            "includes": ["id", "collection", "foo"],
+            "exclude": ["bar"],
+            "include": ["id", "collection", "foo"],
         }
 
         search = ItemSearch(url=SEARCH_URL, fields=["id", "collection", "+foo", "-bar"])
         assert search.get_parameters()["fields"] == {
-            "excludes": ["bar"],
-            "includes": ["id", "collection", "foo"],
+            "exclude": ["bar"],
+            "include": ["id", "collection", "foo"],
         }
 
         search = ItemSearch(
             url=SEARCH_URL,
-            fields={"excludes": ["bar"], "includes": ["id", "collection"]},
+            fields={"exclude": ["bar"], "include": ["id", "collection"]},
         )
         assert search.get_parameters()["fields"] == {
-            "excludes": ["bar"],
-            "includes": ["id", "collection"],
+            "exclude": ["bar"],
+            "include": ["id", "collection"],
         }
 
         search = ItemSearch(
@@ -500,7 +500,7 @@ class TestItemSearchParams:
         search = ItemSearch(
             url=SEARCH_URL,
             method="GET",
-            fields={"excludes": ["bar"], "includes": ["id", "collection"]},
+            fields={"exclude": ["bar"], "include": ["id", "collection"]},
         )
         assert search.get_parameters()["fields"] == "+id,+collection,-bar"
 


### PR DESCRIPTION
**Related Issue(s):** 

- #689


**Description:**

This PR updates the names of the Fields extension keys. Previously they were plural (`includes` / `excludes`) but this did not align with the Fields extension documentation, and did not work when interacting with a STAC API. The keys are renamed to `include` and `exclude` by this PR.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)

Fixes #689
