### PR TITLE
Allow "Feature" dictionaries for intersects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for "Feature" type `intersects` dictionaries [#696](https://github.com/stac-utils/pystac-client/pull/696)
+
 ## [v0.8.1] - 2024-05-23
 
 ### Fixed

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -179,11 +179,10 @@ class ItemSearch:
         bbox: A list, tuple, or iterator representing a bounding box of 2D
             or 3D coordinates. Results will be filtered
             to only those intersecting the bounding box.
-        intersects: A string or dictionary representing a GeoJSON geometry, or
-            an object that implements a
-            ``__geo_interface__`` property, as supported by several libraries
-            including Shapely, ArcPy, PySAL, and
-            geojson. Results filtered to only those intersecting the geometry.
+        intersects: A string or dictionary representing a GeoJSON geometry or feature,
+            or an object that implements a ``__geo_interface__`` property, as supported
+            by several libraries including Shapely, ArcPy, PySAL, and geojson. Results
+            filtered to only those intersecting the geometry.
         datetime: Either a single datetime or datetime range used to filter results.
             You may express a single datetime using a :class:`datetime.datetime`
             instance, a `RFC 3339-compliant <https://tools.ietf.org/html/rfc3339>`__
@@ -646,7 +645,10 @@ class ItemSearch:
         if value is None:
             return None
         if isinstance(value, dict):
-            return deepcopy(value)
+            if value.get("type") == "Feature":
+                return deepcopy(value.get("geometry"))
+            else:
+                return deepcopy(value)
         if isinstance(value, str):
             return dict(json.loads(value))
         if hasattr(value, "__geo_interface__"):

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -850,3 +850,17 @@ def test_fields() -> None:
     assert "geometry" not in item
     assert "assets" not in item
     assert "links" not in item
+
+
+def test_feature() -> None:
+    search = ItemSearch(
+        url="https://earth-search.aws.element84.com/v1/search",
+        intersects={
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [-105.1019, 40.1672]},
+        },
+    )
+    assert search.get_parameters()["intersects"] == {
+        "type": "Point",
+        "coordinates": [-105.1019, 40.1672],
+    }


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #694 


**Description:**

If the `intersects` dictionary has a "Feature" type, use its `geometry` attribute, per the [`__geo_interface__` spec](https://gist.github.com/sgillies/2217756).

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)