### PR TITLE
Remove python 3.9 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -27,9 +26,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-        exclude:  # macos-latest is arm64, which doesn't have this python
-          - os: macos-latest
-            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -64,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Download uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Install dev requirements
@@ -104,7 +100,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Download uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Install with dev requirements
@@ -122,7 +118,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Download uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Python 3.9 support [#724](https://github.com/stac-utils/pystac-client/pull/724)
+
 ## [v0.8.3] - 2024-07-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ license = { text = "Apache-2.0" }
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -25,7 +24,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "requests>=2.28.2",
     "pystac[validation]>=1.10.0",


### PR DESCRIPTION
**Related Issue(s):** 

- Following on from https://github.com/stac-utils/pystac/pull/1384

**Description:**

Our upstream CI check was useful! https://github.com/stac-utils/pystac-client/actions/runs/10267942482/job/28409722839


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)