### PR TITLE
Fix `Client.get_collection` for static catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `Client.get_collection` for static catalogs [#782](https://github.com/stac-utils/pystac-client/pull/782)
+
 ## [v0.8.5] - 2024-10-23
 
 ### Fixed

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -394,7 +394,7 @@ class Client(pystac.Catalog, QueryablesMixin):
         Raises:
             NotFoundError if collection_id does not exist.
         """
-        collection: Union[Collection, CollectionClient]
+        collection: Collection | CollectionClient | None = None
 
         if self._supports_collections():
             assert self._stac_io is not None
@@ -411,6 +411,11 @@ class Client(pystac.Catalog, QueryablesMixin):
             for collection in super().get_collections():
                 if collection.id == collection_id:
                     call_modifier(self.modifier, collection)
+                    break
+
+        if collection is None:
+            raise KeyError(f"Collection {collection_id} not found on catalog")
+
         return collection
 
     def get_collections(self) -> Iterator[Collection]:

--- a/tests/data/test-case-1/catalog.json
+++ b/tests/data/test-case-1/catalog.json
@@ -1,0 +1,24 @@
+{
+  "type": "Catalog",
+  "id": "test",
+  "stac_version": "1.1.0",
+  "description": "test catalog",
+  "links": [
+    {
+      "rel": "child",
+      "href": "./country-1/catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "child",
+      "href": "./country-2/catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "./catalog.json",
+      "type": "application/json"
+    }
+  ],
+  "stac_extensions": []
+}

--- a/tests/data/test-case-1/country-1/area-1-1/area-1-1-imagery/area-1-1-imagery.json
+++ b/tests/data/test-case-1/country-1/area-1-1/area-1-1-imagery/area-1-1-imagery.json
@@ -1,0 +1,70 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "id": "area-1-1-imagery",
+  "properties": {
+    "datetime": "2019-10-04T18:55:37Z"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "collection",
+      "href": "../collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "ortho": {
+      "href": "http://example.com/area-1-1_ortho.tif",
+      "type": "image/vnd.stac.geotiff"
+    },
+    "dsm": {
+      "href": "http://example.com/area-1-1_dsm.tif",
+      "type": "image/vnd.stac.geotiff"
+    }
+  },
+  "bbox": [
+    -2.5048828125,
+    3.8916575492899987,
+    -1.9610595703125,
+    3.8916575492899987
+  ],
+  "stac_extensions": [],
+  "collection": "area-1-1"
+}

--- a/tests/data/test-case-1/country-1/area-1-1/area-1-1-labels/area-1-1-labels.json
+++ b/tests/data/test-case-1/country-1/area-1-1/area-1-1-labels/area-1-1-labels.json
@@ -1,0 +1,93 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "id": "area-1-1-labels",
+  "properties": {
+    "datetime": "2019-10-04T18:55:37Z",
+    "label:description": "labels for area-1-1",
+    "label:type": "vector",
+    "label:properties": [
+      "label"
+    ],
+    "label:classes": [
+      {
+        "name": "label",
+        "classes": [
+          "one",
+          "two"
+        ]
+      }
+    ],
+    "label:tasks": [
+      "classification"
+    ],
+    "label:methods": [
+      "manual"
+    ]
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "source",
+      "href": "../area-1-1-imagery/area-1-1-imagery.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "../collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "labels": {
+      "href": "http://example.com/area-1-1-labels.geojson",
+      "type": "application/geo+json"
+    }
+  },
+  "bbox": [
+    -2.5048828125,
+    3.8916575492899987,
+    -1.9610595703125,
+    3.8916575492899987
+  ],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
+  ],
+  "collection": "area-1-1"
+}

--- a/tests/data/test-case-1/country-1/area-1-1/collection.json
+++ b/tests/data/test-case-1/country-1/area-1-1/collection.json
@@ -1,0 +1,50 @@
+{
+  "type": "Collection",
+  "id": "area-1-1",
+  "stac_version": "1.1.0",
+  "description": "test collection country-1",
+  "links": [
+    {
+      "rel": "item",
+      "href": "./area-1-1-imagery/area-1-1-imagery.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "./area-1-1-labels/area-1-1-labels.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json"
+    }
+  ],
+  "stac_extensions": [],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -2.5048828125,
+          3.8916575492899987,
+          -1.9610595703125,
+          4.275202171119132
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2019-10-04T18:55:37Z",
+          null
+        ]
+      ]
+    }
+  },
+  "license": "other"
+}

--- a/tests/data/test-case-1/country-1/area-1-2/area-1-2-imagery/area-1-2-imagery.json
+++ b/tests/data/test-case-1/country-1/area-1-2/area-1-2-imagery/area-1-2-imagery.json
@@ -1,0 +1,70 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "id": "area-1-2-imagery",
+  "properties": {
+    "datetime": "2019-10-04T18:55:37Z"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "collection",
+      "href": "../collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "ortho": {
+      "href": "http://example.com/area-1-2_ortho.tif",
+      "type": "image/vnd.stac.geotiff"
+    },
+    "dsm": {
+      "href": "http://example.com/area-1-2_dsm.tif",
+      "type": "image/vnd.stac.geotiff"
+    }
+  },
+  "bbox": [
+    -2.5048828125,
+    3.8916575492899987,
+    -1.9610595703125,
+    3.8916575492899987
+  ],
+  "stac_extensions": [],
+  "collection": "area-1-2"
+}

--- a/tests/data/test-case-1/country-1/area-1-2/area-1-2-labels/area-1-2-labels.json
+++ b/tests/data/test-case-1/country-1/area-1-2/area-1-2-labels/area-1-2-labels.json
@@ -1,0 +1,93 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "id": "area-1-2-labels",
+  "properties": {
+    "datetime": "2019-10-04T18:55:37Z",
+    "label:description": "labels for area-1-2",
+    "label:type": "vector",
+    "label:properties": [
+      "label"
+    ],
+    "label:classes": [
+      {
+        "name": "label",
+        "classes": [
+          "one",
+          "two"
+        ]
+      }
+    ],
+    "label:tasks": [
+      "classification"
+    ],
+    "label:methods": [
+      "manual"
+    ]
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "source",
+      "href": "../area-1-2-imagery/area-1-2-imagery.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "../collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "labels": {
+      "href": "http://example.com/area-1-2-labels.geojson",
+      "type": "application/geo+json"
+    }
+  },
+  "bbox": [
+    -2.5048828125,
+    3.8916575492899987,
+    -1.9610595703125,
+    3.8916575492899987
+  ],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
+  ],
+  "collection": "area-1-2"
+}

--- a/tests/data/test-case-1/country-1/area-1-2/collection.json
+++ b/tests/data/test-case-1/country-1/area-1-2/collection.json
@@ -1,0 +1,50 @@
+{
+  "type": "Collection",
+  "id": "area-1-2",
+  "stac_version": "1.1.0",
+  "description": "test collection country-1",
+  "links": [
+    {
+      "rel": "item",
+      "href": "./area-1-2-imagery/area-1-2-imagery.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "./area-1-2-labels/area-1-2-labels.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json"
+    }
+  ],
+  "stac_extensions": [],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -2.5048828125,
+          3.8916575492899987,
+          -1.9610595703125,
+          4.275202171119132
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2019-10-04T18:55:37Z",
+          null
+        ]
+      ]
+    }
+  },
+  "license": "other"
+}

--- a/tests/data/test-case-1/country-1/catalog.json
+++ b/tests/data/test-case-1/country-1/catalog.json
@@ -1,0 +1,29 @@
+{
+  "type": "Catalog",
+  "id": "country-1",
+  "stac_version": "1.1.0",
+  "description": "test catalog country-1",
+  "links": [
+    {
+      "rel": "child",
+      "href": "./area-1-1/collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "child",
+      "href": "./area-1-2/collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json"
+    }
+  ],
+  "stac_extensions": []
+}

--- a/tests/data/test-case-1/country-2/area-2-1/area-2-1-imagery/area-2-1-imagery.json
+++ b/tests/data/test-case-1/country-2/area-2-1/area-2-1-imagery/area-2-1-imagery.json
@@ -1,0 +1,70 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "id": "area-2-1-imagery",
+  "properties": {
+    "datetime": "2019-10-04T18:55:37Z"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "collection",
+      "href": "../collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "ortho": {
+      "href": "http://example.com/area-2-1_ortho.tif",
+      "type": "image/vnd.stac.geotiff"
+    },
+    "dsm": {
+      "href": "http://example.com/area-2-1_dsm.tif",
+      "type": "image/vnd.stac.geotiff"
+    }
+  },
+  "bbox": [
+    -2.5048828125,
+    3.8916575492899987,
+    -1.9610595703125,
+    3.8916575492899987
+  ],
+  "stac_extensions": [],
+  "collection": "area-2-1"
+}

--- a/tests/data/test-case-1/country-2/area-2-1/area-2-1-labels/area-2-1-labels.json
+++ b/tests/data/test-case-1/country-2/area-2-1/area-2-1-labels/area-2-1-labels.json
@@ -1,0 +1,93 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "id": "area-2-1-labels",
+  "properties": {
+    "datetime": "2019-10-04T18:55:37Z",
+    "label:description": "labels for area-2-1",
+    "label:type": "vector",
+    "label:properties": [
+      "label"
+    ],
+    "label:classes": [
+      {
+        "name": "label",
+        "classes": [
+          "one",
+          "two"
+        ]
+      }
+    ],
+    "label:tasks": [
+      "classification"
+    ],
+    "label:methods": [
+      "manual"
+    ]
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "source",
+      "href": "../area-2-1-imagery/area-2-1-imagery.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "../collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "labels": {
+      "href": "http://example.com/area-2-1-labels.geojson",
+      "type": "application/geo+json"
+    }
+  },
+  "bbox": [
+    -2.5048828125,
+    3.8916575492899987,
+    -1.9610595703125,
+    3.8916575492899987
+  ],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
+  ],
+  "collection": "area-2-1"
+}

--- a/tests/data/test-case-1/country-2/area-2-1/collection.json
+++ b/tests/data/test-case-1/country-2/area-2-1/collection.json
@@ -1,0 +1,50 @@
+{
+  "type": "Collection",
+  "id": "area-2-1",
+  "stac_version": "1.1.0",
+  "description": "test collection country-2",
+  "links": [
+    {
+      "rel": "item",
+      "href": "./area-2-1-imagery/area-2-1-imagery.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "./area-2-1-labels/area-2-1-labels.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json"
+    }
+  ],
+  "stac_extensions": [],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -2.5048828125,
+          3.8916575492899987,
+          -1.9610595703125,
+          4.275202171119132
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2019-10-04T18:55:37Z",
+          null
+        ]
+      ]
+    }
+  },
+  "license": "other"
+}

--- a/tests/data/test-case-1/country-2/area-2-2/area-2-2-imagery/area-2-2-imagery.json
+++ b/tests/data/test-case-1/country-2/area-2-2/area-2-2-imagery/area-2-2-imagery.json
@@ -1,0 +1,70 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "id": "area-2-2-imagery",
+  "properties": {
+    "datetime": "2019-10-04T18:55:37Z"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "collection",
+      "href": "../collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "ortho": {
+      "href": "http://example.com/area-2-2_ortho.tif",
+      "type": "image/vnd.stac.geotiff"
+    },
+    "dsm": {
+      "href": "http://example.com/area-2-2_dsm.tif",
+      "type": "image/vnd.stac.geotiff"
+    }
+  },
+  "bbox": [
+    -2.5048828125,
+    3.8916575492899987,
+    -1.9610595703125,
+    3.8916575492899987
+  ],
+  "stac_extensions": [],
+  "collection": "area-2-2"
+}

--- a/tests/data/test-case-1/country-2/area-2-2/area-2-2-labels/area-2-2-labels.json
+++ b/tests/data/test-case-1/country-2/area-2-2/area-2-2-labels/area-2-2-labels.json
@@ -1,0 +1,93 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "id": "area-2-2-labels",
+  "properties": {
+    "datetime": "2019-10-04T18:55:37Z",
+    "label:description": "labels for area-2-2",
+    "label:type": "vector",
+    "label:properties": [
+      "label"
+    ],
+    "label:classes": [
+      {
+        "name": "label",
+        "classes": [
+          "one",
+          "two"
+        ]
+      }
+    ],
+    "label:tasks": [
+      "classification"
+    ],
+    "label:methods": [
+      "manual"
+    ]
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "source",
+      "href": "../area-2-2-imagery/area-2-2-imagery.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "../collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "labels": {
+      "href": "http://example.com/area-2-2-labels.geojson",
+      "type": "application/geo+json"
+    }
+  },
+  "bbox": [
+    -2.5048828125,
+    3.8916575492899987,
+    -1.9610595703125,
+    3.8916575492899987
+  ],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
+  ],
+  "collection": "area-2-2"
+}

--- a/tests/data/test-case-1/country-2/area-2-2/collection.json
+++ b/tests/data/test-case-1/country-2/area-2-2/collection.json
@@ -1,0 +1,50 @@
+{
+  "type": "Collection",
+  "id": "area-2-2",
+  "stac_version": "1.1.0",
+  "description": "test collection country-2",
+  "links": [
+    {
+      "rel": "item",
+      "href": "./area-2-2-imagery/area-2-2-imagery.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "./area-2-2-labels/area-2-2-labels.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json"
+    }
+  ],
+  "stac_extensions": [],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -2.5048828125,
+          3.8916575492899987,
+          -1.9610595703125,
+          4.275202171119132
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2019-10-04T18:55:37Z",
+          null
+        ]
+      ]
+    }
+  },
+  "license": "other"
+}

--- a/tests/data/test-case-1/country-2/catalog.json
+++ b/tests/data/test-case-1/country-2/catalog.json
@@ -1,0 +1,29 @@
+{
+  "type": "Catalog",
+  "id": "country-2",
+  "stac_version": "1.1.0",
+  "description": "test catalog country-2",
+  "links": [
+    {
+      "rel": "child",
+      "href": "./area-2-1/collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "child",
+      "href": "./area-2-2/collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json"
+    }
+  ],
+  "stac_extensions": []
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -793,6 +793,28 @@ def test_fallback_strategy() -> None:
     assert item_root.href == root_href
 
 
+def test_get_collection_fallback_strategy_for_static_catalogs() -> None:
+    client = Client.from_file(
+        str(TEST_DATA / "test-case-1" / "country-1" / "catalog.json")
+    )
+
+    with pytest.warns(FallbackToPystac):
+        area_1_1 = client.get_collection("area-1-1")
+
+    with pytest.warns(FallbackToPystac):
+        area_1_2 = client.get_collection("area-1-2")
+
+    assert area_1_1.id == "area-1-1"
+    assert area_1_2.id == "area-1-2"
+
+
+def test_get_collection_for_static_catalogs_raise_if_not_found() -> None:
+    client = Client.from_file(str(TEST_DATA / "test-case-1" / "catalog.json"))
+    with pytest.raises(KeyError, match="not found on catalog"):
+        with pytest.warns(FallbackToPystac):
+            client.get_collection("country-1")
+
+
 @pytest.mark.vcr
 def test_query_string_in_collections_url() -> None:
     # https://github.com/stac-utils/pystac-client/issues/745


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #780 


**Description:**

* add static catalog to test data (copied from pystac)
* ensure that `Client.get_collection` returns specified collection
* ensure that if no matching collection is found it raises

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)