### PR TITLE
fix: permissive extent parsing for collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `Client.get_collection` for static catalogs [#782](https://github.com/stac-utils/pystac-client/pull/782)
+- Permissive collection reading [#787](https://github.com/stac-utils/pystac-client/pull/787)
 
 ## [v0.8.5] - 2024-10-23
 

--- a/pystac_client/cli.py
+++ b/pystac_client/cli.py
@@ -124,7 +124,7 @@ def collections(
             else:
                 raise KeyError("'matched' is not supported for this catalog")
         else:
-            collections_dicts = [c.to_dict() for c in result.collections()]
+            collections_dicts = list(result.collections_as_dicts())
             if save:
                 with open(save, "w") as f:
                     f.write(json.dumps(collections_dicts))
@@ -257,8 +257,7 @@ def parse_args(args: list[str]) -> dict[str, Any]:
     )
     collections_group.add_argument(
         "--datetime",
-        help="Single datetime or begin and end datetime "
-        "(e.g., 2017-01-01/2017-02-15)",
+        help="Single datetime or begin and end datetime (e.g., 2017-01-01/2017-02-15)",
     )
     collections_group.add_argument("--q", help="Free-text search query")
     collections_group.add_argument(
@@ -318,8 +317,7 @@ def parse_args(args: list[str]) -> dict[str, Any]:
     )
     search_group.add_argument(
         "--datetime",
-        help="Single datetime or begin and end datetime "
-        "(e.g., 2017-01-01/2017-02-15)",
+        help="Single datetime or begin and end datetime (e.g., 2017-01-01/2017-02-15)",
     )
     search_group.add_argument(
         "--query",

--- a/tests/data/invalid-collection.json
+++ b/tests/data/invalid-collection.json
@@ -1,0 +1,37 @@
+{
+    "id": "planet",
+    "title": "Planet",
+    "extent": {},
+    "license": "proprietary",
+    "description": "Planet",
+    "stac_version": "1.0.0",
+    "item_type_accessor": "pl:item_type",
+    "links": [
+        {
+            "rel": "items",
+            "type": "application/geo+json",
+            "href": "https://csdap.earthdata.nasa.gov/stac/collections/planet/items"
+        },
+        {
+            "rel": "parent",
+            "type": "application/json",
+            "href": "https://csdap.earthdata.nasa.gov/stac/"
+        },
+        {
+            "rel": "root",
+            "type": "application/json",
+            "href": "https://csdap.earthdata.nasa.gov/stac/"
+        },
+        {
+            "rel": "self",
+            "type": "application/json",
+            "href": "https://csdap.earthdata.nasa.gov/stac/collections/planet"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+            "type": "application/schema+json",
+            "title": "Queryables",
+            "href": "https://csdap.earthdata.nasa.gov/stac/collections/planet/queryables"
+        }
+    ]
+}

--- a/tests/test_collection_search.py
+++ b/tests/test_collection_search.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from math import ceil
 from typing import Any
@@ -12,8 +13,10 @@ from pystac_client.client import Client
 from pystac_client.collection_search import (
     CollectionSearch,
     bboxes_overlap,
+    collection_matches,
     temporal_intervals_overlap,
 )
+from pystac_client.warnings import PystacClientWarning
 
 from .helpers import STAC_URLS, read_data_file
 
@@ -387,3 +390,10 @@ def test_temporal_intervals_overlap() -> None:
             None,
         ),
     )
+
+
+def test_invalid_collection() -> None:
+    # https://github.com/stac-utils/pystac-client/issues/786
+    data = json.loads(read_data_file("invalid-collection.json"))
+    with pytest.warns(PystacClientWarning):
+        collection_matches(data)


### PR DESCRIPTION
**Related Issue(s):** 

- Closes https://github.com/stac-utils/pystac-client/issues/786


**Description:**

We were overly strict when parsing collections, causing an error when the collections are invalid (which happens out there quite a lot).

cc @ceholden @aliziel


**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)