### PR TITLE
Fix usage documentation of `ItemSearch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix usage documentation of `ItemSearch`
+
 ## [v0.8.6] - 2025-02-11
 
 ### Changed

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -372,7 +372,7 @@ requests to a service's "search" endpoint. This method returns a
     >>> from pystac_client import Client
     >>> catalog = Client.open('https://planetarycomputer.microsoft.com/api/stac/v1')
     >>> results = catalog.search(
-    ...     max_items=5
+    ...     max_items=5,
     ...     bbox=[-73.21, 43.99, -73.12, 44.05],
     ...     datetime=['2019-01-01T00:00:00Z', '2019-01-02T00:00:00Z'],
     ... )


### PR DESCRIPTION
**Related Issue(s):** 

- #


**Description:**

This PR fixes a missing comma in https://pystac-client.readthedocs.io/en/latest/usage.html#itemsearch

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)