### PR TITLE
Fix Documentation Rendering on Usage and ItemSearch pages

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -357,7 +357,7 @@ ItemSearch
 
 STAC API services may optionally implement a ``/search`` endpoint as describe in the
 `STAC API - Item Search spec
-<https://github.com/radiantearth/stac-api-spec/tree/main/item-search`__. This
+<https://github.com/radiantearth/stac-api-spec/tree/main/item-search>`__. This
 endpoint allows clients to query STAC Items across the entire service using a variety
 of filter parameters. See the `Query Parameter Table
 <https://github.com/radiantearth/stac-api-spec/tree/main/item-search#query-parameter-table>`__

--- a/pystac_client/item_search.py
+++ b/pystac_client/item_search.py
@@ -594,7 +594,7 @@ class ItemSearch(BaseSearch):
     through the resulting STAC Items, either :meth:`ItemSearch.item_collections`,
     :meth:`ItemSearch.items`, or :meth:`ItemSearch.items_as_dicts`.
 
-    All parameters except `url``, ``method``, ``max_items``, and ``client``
+    All parameters except ``url``, ``method``, ``max_items``, and ``client``
     correspond to query parameters
     described in the `STAC API - Item Search: Query Parameters Table
     <https://github.com/radiantearth/stac-api-spec/tree/master/item-search#query-parameter-table>`__


### PR DESCRIPTION
**Description:**

Fix a couple of tiny syntax errors in the documentation which affect the rendering.


**PR Checklist:**
I've built the documentation locally, the changes work.

I don't think these items are required:
- [ ] Code is formatted
- [ ] Tests pass
- [ ] Changes are added to CHANGELOG.md
