### PR TITLE
Try to fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,11 +13,6 @@ build:
       - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
     install:
       - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --group docs --link-mode=copy
-    build:
-      html:
-        - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv run -- sphinx-build -M html docs $READTHEDOCS_OUTPUT
-      pdf:
-        - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv run -- sphinx-build -M latexpdf docs $READTHEDOCS_OUTPUT
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
I noticed that readthedocs has been failing (https://app.readthedocs.org/projects/pystac-client/builds/28904005/) for a while now. Not totally sure how to test this but it is based off of https://docs.readthedocs.com/platform/stable/build-customization.html#install-dependencies-with-uv which seems like a pretty good source of truth ¯\_(ツ)_/¯ 
