### PR TITLE
fix: warn when item search method is not advertised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Warn when the requested item-search method is not advertised ([#912](https://github.com/stac-utils/pystac-client/pull/912))
 - Add test coverage for stac_api_io.py error handling ([#835](https://github.com/stac-utils/pystac-client/pull/835))
 - Add comprehensive test coverage for warning context managers (`ignore()` and `strict()`) ([#832](https://github.com/stac-utils/pystac-client/pull/832))
 - Moved -Werror to pyproject.toml ([#841](https://github.com/stac-utils/pystac-client/pull/841))

--- a/pystac_client/client.py
+++ b/pystac_client/client.py
@@ -621,6 +621,20 @@ class Client(pystac.Catalog, QueryablesMixin):
                 "ITEM_SEARCH", "There is no fallback option available for search."
             )
 
+        requested_method = method or "POST"
+        advertised_methods = {
+            link.extra_fields.get("method", "GET") or "GET"
+            for link in self._get_search_links()
+        }
+        if advertised_methods and requested_method not in advertised_methods:
+            warnings.warn(
+                f"The requested method '{requested_method}' is not advertised by "
+                "any root catalog search link. Available methods: "
+                f"{', '.join(sorted(advertised_methods))}",
+                PystacClientWarning,
+                stacklevel=2,
+            )
+
         return ItemSearch(
             url=self._search_href(),
             method=method,
@@ -776,6 +790,17 @@ class Client(pystac.Catalog, QueryablesMixin):
             modifier=self.modifier,
         )
 
+    def _get_search_links(self) -> Iterator[pystac.Link]:
+        return (
+            link
+            for link in self.links
+            if link.rel == "search"
+            and (
+                link.media_type == pystac.MediaType.GEOJSON
+                or link.media_type == pystac.MediaType.JSON
+            )
+        )
+
     def get_search_link(self) -> pystac.Link | None:
         """Returns this client's search link.
 
@@ -784,18 +809,7 @@ class Client(pystac.Catalog, QueryablesMixin):
         Returns:
             Optional[pystac.Link]: The search link, or None if there is not one found.
         """
-        return next(
-            (
-                link
-                for link in self.links
-                if link.rel == "search"
-                and (
-                    link.media_type == pystac.MediaType.GEOJSON
-                    or link.media_type == pystac.MediaType.JSON
-                )
-            ),
-            None,
-        )
+        return next(self._get_search_links(), None)
 
     def _search_href(self) -> str:
         search_link = self.get_search_link()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,6 +23,7 @@ from pystac_client.warnings import (
     FallbackToPystac,
     MissingLink,
     NoConformsTo,
+    PystacClientWarning,
     strict,
 )
 
@@ -434,7 +435,11 @@ class TestAPI:
 class TestAPISearch:
     @pytest.fixture(scope="function")
     def api(self) -> Client:
-        return Client.from_file(str(TEST_DATA / "planetary-computer-root.json"))
+        api = Client.from_file(str(TEST_DATA / "planetary-computer-root.json"))
+        search_link = api.get_search_link()
+        assert search_link
+        search_link.extra_fields["method"] = "POST"
+        return api
 
     def test_search_conformance_error(self, api: Client) -> None:
         # Remove item search conformance
@@ -492,6 +497,69 @@ class TestAPISearch:
         search_link.media_type = MediaType.JSON
         api.add_link(search_link)
         api.search(limit=1, max_items=1, collections="naip")
+
+    @pytest.mark.parametrize(
+        ("advertised_method", "requested_method", "available_method"),
+        [
+            (None, "POST", "GET"),
+            ("GET", "POST", "GET"),
+            ("POST", "GET", "POST"),
+            ("GET", None, "GET"),
+        ],
+    )
+    def test_search_warns_if_method_is_not_advertised(
+        self,
+        api: Client,
+        advertised_method: str | None,
+        requested_method: str | None,
+        available_method: str,
+    ) -> None:
+        search_link = api.get_search_link()
+        assert search_link
+        search_link.extra_fields = (
+            {"method": advertised_method} if advertised_method else {}
+        )
+
+        requested_method_name = requested_method or "POST"
+        with pytest.warns(
+            PystacClientWarning,
+            match=(
+                f"requested method '{requested_method_name}'.*"
+                f"Available methods: {available_method}"
+            ),
+        ):
+            api.search(method=requested_method)
+
+    @pytest.mark.parametrize(
+        ("advertised_methods", "requested_method"),
+        [
+            (("GET", "POST"), "GET"),
+            (("GET", "POST"), "POST"),
+            (("POST",), None),
+        ],
+    )
+    def test_search_does_not_warn_if_method_is_advertised(
+        self,
+        api: Client,
+        advertised_methods: tuple[str, ...],
+        requested_method: str | None,
+    ) -> None:
+        search_link = api.get_search_link()
+        assert search_link
+        api.remove_links("search")
+        for method in advertised_methods:
+            api.add_link(
+                pystac.Link(
+                    rel="search",
+                    target=search_link.target,
+                    media_type=search_link.media_type,
+                    extra_fields={"method": method},
+                )
+            )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", PystacClientWarning)
+            api.search(method=requested_method)
 
     @pytest.mark.vcr
     def test_search_max_items_unlimited_default(self, api: Client) -> None:


### PR DESCRIPTION
**Related Issue(s):**

- Fixes #900

**Description:**

- Warn when the requested item-search HTTP method is not advertised by any compatible root-catalog search link.
- Treat links without a method as GET while leaving the requested method, search URL, and existing fallback behavior unchanged.
- Cover GET, POST, multiple-link, omitted-link-method, and default-request-method cases.

**Verification:**

- `pytest tests/test_client.py -q` (52 passed)
- `pytest -p no:unraisableexception --cov pystac_client --cov-report term-missing` (212 passed, 6 skipped, 95% coverage)
- `ruff check .`
- `ruff format --check .`
- `mypy pystac_client tests`
- changed-file codespell and `git diff --check`

The unmodified default test command is affected locally by pre-existing SQLite resource warnings on Python 3.13 and 3.14; the same failures were reproduced on the unchanged main branch.

**PR Checklist:**

- [x] Code is formatted
- [x] Tests pass
- [x] Changes are added to CHANGELOG.md
