### PR TITLE
docs: add Retry to StacApiIO doc

### DIFF
--- a/pystac_client/stac_api_io.py
+++ b/pystac_client/stac_api_io.py
@@ -67,8 +67,9 @@ class StacApiIO(DefaultStacIO):
             timeout: Optional float or (float, float) tuple following the semantics
               defined by `Requests
               <https://requests.readthedocs.io/en/latest/api/#main-interface>`__.
-            max_retries: The number of times to retry requests. Set to ``None`` to
-              disable retries.
+            max_retries: The number of times to retry requests or an
+              ``urllib3.utils.Retry`` instance for more advanced retry configurations.
+              Set to ``None`` to disable retries.
 
         Return:
             StacApiIO : StacApiIO instance


### PR DESCRIPTION
Small update to the docstring of the `StacApiIO` class to specify that `max_retries` can also be a urllib3 `Retry` class and not only a number. I found the docstring a bit misleading since the class constructor is also type-hinting the Retry: `max_retries: int | Retry | None = 5`.

**PR Checklist:**

- [x] Code is formatted
- [ ] Tests pass
- [ ] Changes are added to CHANGELOG.md
